### PR TITLE
Security: Dependency bumps (flatted, picomatch) + palette-designer XSS fix

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,16 @@
 <!-- markdownlint-disable MD024 -->
 # Segment Reporting - Release Notes
 
+## [v1.3.0.1](https://github.com/sydlexius/Segment_Reporting/releases/tag/v1.3.0.1) - Security Maintenance
+
+### Fixed
+
+- **Cross-site scripting hardening in the palette designer tool** (CodeQL #1) - The internal color palette designer now validates that pasted colors are valid hex values before rendering them, closing a potential script-injection path.
+
+### Security
+
+- **Dependency updates** - Bumped build-time JavaScript dependencies to patched releases: flatted 3.3.3 to 3.4.2 (#83) and picomatch 4.0.3 to 4.0.4 (#85). These are development-only dependencies and do not affect the shipped plugin.
+
 ## [v1.3.0.0](https://github.com/sydlexius/Segment_Reporting/releases/tag/v1.3.0.0) - Theme-Aware Palettes and Actions Overhaul
 
 ### Improved

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,13 +3,12 @@
 
 ## [v1.3.0.1](https://github.com/sydlexius/Segment_Reporting/releases/tag/v1.3.0.1) - Security Maintenance
 
-### Fixed
-
-- **Cross-site scripting hardening in the palette designer tool** (CodeQL #1) - The internal color palette designer now validates that pasted colors are valid hex values before rendering them, closing a potential script-injection path.
+Housekeeping release. No new features and no action required for admins. All changes are confined to development-only tooling, so the shipped plugin behaves exactly as in v1.3.0.0.
 
 ### Security
 
-- **Dependency updates** - Bumped build-time JavaScript dependencies to patched releases: flatted 3.3.3 to 3.4.2 (#83) and picomatch 4.0.3 to 4.0.4 (#85). These are development-only dependencies and do not affect the shipped plugin.
+- **Palette designer hardening** (CodeQL #1) - The developer-only color palette designer now validates that pasted colors are valid hex values before displaying them, closing a potential script-injection path. This tool ships only in the source repository and is not part of the installed plugin.
+- **Build dependency updates** - Updated build-time JavaScript dependencies to their patched releases: flatted 3.3.3 to 3.4.2 (#83) and picomatch 4.0.3 to 4.0.4 (#85). Both are development-only dependencies used during the build and are not bundled into the plugin.
 
 ## [v1.3.0.0](https://github.com/sydlexius/Segment_Reporting/releases/tag/v1.3.0.0) - Theme-Aware Palettes and Actions Overhaul
 

--- a/segment_reporting/Properties/AssemblyInfo.cs
+++ b/segment_reporting/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.3.0.1")]
+[assembly: AssemblyFileVersion("1.3.0.1")]

--- a/segment_reporting/package-lock.json
+++ b/segment_reporting/package-lock.json
@@ -2066,9 +2066,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/segment_reporting/package-lock.json
+++ b/segment_reporting/package-lock.json
@@ -2528,9 +2528,9 @@
       "license": "MIT"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/tools/palette-designer.html
+++ b/tools/palette-designer.html
@@ -348,10 +348,21 @@ function copyInline(el) {
   });
 }
 
+// Accept only hex colors (#rgb, #rrggbb, or #rrggbbaa). Rejecting anything
+// else keeps untrusted text from reaching the innerHTML sinks below.
+function isHexColor(c) {
+  return typeof c === 'string' && /^#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3}(?:[0-9a-fA-F]{2})?)?$/.test(c);
+}
+
 function loadColors() {
   try {
     var raw = document.getElementById('colorInput').value.trim();
-    currentColors = JSON.parse(raw);
+    var parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed) || parsed.length === 0 || !parsed.every(isHexColor)) {
+      alert('Invalid color list. Use hex colors only, e.g. ["#52b54b","#344047","#127dbc"]');
+      return;
+    }
+    currentColors = parsed;
     roleMap = {};
     themeMap = {};
     if (currentColors.length === 3) {


### PR DESCRIPTION
Consolidated security maintenance PR. Replaces the two dependabot PRs that were closed with their branches deleted (so dependabot could not recreate them), and addresses CodeQL alert #1.

## Changes

### Dependency bumps (replaces closed #83 and #85)
- **flatted 3.3.3 -> 3.4.2** (#83) - fixes CWE-1321 (prototype pollution)
- **picomatch 4.0.3 -> 4.0.4** (#85) - fixes CVE-2026-33671 and CVE-2026-33672

Both are transitive **dev-only** dependencies (build tooling). Lockfile-only changes via `npm update`; the new versions satisfy the existing semver ranges, so `package.json` is untouched and the shipped plugin is unaffected.

### CodeQL alert #1 - DOM XSS (`js/xss-through-dom`)
`tools/palette-designer.html` parsed the `colorInput` text field as JSON and fed the strings straight into `innerHTML` across several render functions, so a crafted entry like `["<img src=x onerror=...>"]` could execute. `loadColors()` now validates that every parsed entry is a hex color (`#rgb` / `#rrggbb` / `#rrggbbaa`) and rejects otherwise, neutralizing the taint at its single entry point. The accent/none colors come from `<input type="color">` and are already browser-constrained.

### Version bump
- `1.3.0.0` -> `1.3.0.1` (AssemblyInfo + RELEASE_NOTES).

## Testing
- `dotnet build -c Release` succeeds (0 warnings, 0 errors).
- Verified the hex-validation regex accepts legitimate palettes and rejects injection payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)