### PR TITLE
test: xUnit test project + developer Makefile (#106 Phase 1)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,9 @@ indent_size = 2
 [*.sln]
 indent_style = tab
 
+[{Makefile,*.mk}]
+indent_style = tab
+
 [*.md]
 trim_trailing_whitespace = false
 

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copy to .env and fill in real values. .env is gitignored - never commit it.
+# Local Emby servers used for screenshots (prod) and abuse/fuzz/BRU (UAT).
+
+# --- Production Emby server (real data; anonymize before screenshots) ---
+EMBY_PROD_URL=http://HOST:8096
+EMBY_PROD_URL_HTTPS=https://HOST:8920
+EMBY_PROD_API_KEY=
+
+# --- UAT Emby server (localhost; safe to abuse) ---
+EMBY_UAT_URL=http://localhost:8096
+EMBY_UAT_API_KEY=

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Build with analyzers
         run: dotnet build Segment_Reporting.sln --configuration Release --no-restore -warnaserror
 
+      - name: Run tests
+        run: dotnet test Segment_Reporting.sln --configuration Release --no-build
+
       - name: Check code formatting
         run: dotnet format Segment_Reporting.sln --verify-no-changes --no-restore
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ project.lock.json
 
 ## MkDocs generated site output (docs site_dir)
 /site/
+
+## Secrets (local env; see .env.example)
+.env
+.env.*
+!.env.example

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,17 +6,26 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Segment Reporting is an Emby server plugin (C#/.NET) that caches media segment markers (Intros, Credits) into a local SQLite database and provides admin-facing reporting, charts, inline editing, and bulk management through embedded web pages. Licensed GPL-3.0.
 
-The design document at [docs/plans/2026-02-06-segment-reporting-design.md](docs/plans/2026-02-06-segment-reporting-design.md) is the authoritative specification — consult it for all data model details, API contracts, UI page specs, and sync behavior.
+The design document at [docs/plans/2026-02-06-segment-reporting-design.md](docs/plans/2026-02-06-segment-reporting-design.md) is the authoritative specification - consult it for all data model details, API contracts, UI page specs, and sync behavior.
 
 ## Build & Run
+
+Common dev tasks are wrapped in a `Makefile` (run `make help` for the full
+list: `build`, `test`, `format`, `lint`, `gate`, `hooks`, `docs`, `screenshots`,
+`clean`). The Makefile only wraps the commands below; CI invokes them directly.
 
 ```bash
 # Restore and build
 dotnet restore segment_reporting/segment_reporting.csproj
 dotnet build segment_reporting/segment_reporting.csproj -c Release
 
-# No automated tests — Emby plugins require a running server instance
-# Manual testing: copy the built DLL into Emby's plugins directory and restart
+# Unit tests (xUnit) for pure logic (custom-query validators, marker types).
+# The test project targets net8.0 (matches CI); RollForward lets it run on a
+# newer local runtime if the 8.0 runtime is not installed.
+dotnet test Segment_Reporting.sln
+
+# Integration/manual testing still requires a running Emby server: copy the
+# built DLL into Emby's plugins directory and restart.
 ```
 
 ## Architecture
@@ -31,20 +40,20 @@ This plugin follows the architecture pattern established by [playback_reporting]
 - Sync: Scheduled task crawls `ILibraryManager` + `IItemRepository` -> rebuilds SQLite cache
 
 **Key components:**
-- `Plugin.cs` / `PluginConfiguration.cs` — Plugin entry point and config
-- `Data/SegmentRepository.cs` — SQLite singleton, schema creation/migration, all queries
-- `Data/SegmentInfo.cs` — Model class for the denormalized `MediaSegments` table
-- `Api/SegmentReportingAPI.cs` — All REST endpoints under `/segment_reporting/` prefix (admin-only)
-- `Tasks/TaskSyncSegments.cs` — Scheduled daily sync (crawl all libraries, upsert cache)
-- `Tasks/TaskCleanSegmentDb.cs` — Weekly VACUUM and health check
-- `Pages/` — Six embedded HTML/JS pages using Emby's `data-controller` / AMD module pattern
+- `Plugin.cs` / `PluginConfiguration.cs` - Plugin entry point and config
+- `Data/SegmentRepository.cs` - SQLite singleton, schema creation/migration, all queries
+- `Data/SegmentInfo.cs` - Model class for the denormalized `MediaSegments` table
+- `Api/SegmentReportingAPI.cs` - All REST endpoints under `/segment_reporting/` prefix (admin-only)
+- `Tasks/TaskSyncSegments.cs` - Scheduled daily sync (crawl all libraries, upsert cache)
+- `Tasks/TaskCleanSegmentDb.cs` - Weekly VACUUM and health check
+- `Pages/` - Six embedded HTML/JS pages using Emby's `data-controller` / AMD module pattern
 
 **SQLite schema:** Single denormalized `MediaSegments` table (no joins needed for custom queries). Movies and episodes share the same table; series/season columns are null for movies. Schema migration uses `PRAGMA table_info` + `ALTER TABLE ADD`.
 
 ## Dependencies
 
-- `mediabrowser.server.core` (4.8.x) — Emby server SDK
-- `SQLitePCL.pretty.core` (1.2.2) — SQLite wrapper
+- `mediabrowser.server.core` (4.9.x) - Emby server SDK (plugin targets `netstandard2.0`)
+- `SQLitePCL.pretty.core` (1.2.2) - SQLite wrapper
 - `System.Memory` (4.5.5)
 
 ## Conventions
@@ -55,7 +64,7 @@ This plugin follows the architecture pattern established by [playback_reporting]
 - Segment types: `IntroStart`, `IntroEnd`, `CreditsStart` (the three types Emby currently supports)
 - Time values stored as ticks (BIGINT), displayed as `HH:MM:SS.fff`
 - Shared utilities live in `Pages/segment_reporting_helpers.js` (tick conversion, chart navigation, API helpers, HTML escaping)
-- Avoid em-dashes (`—`) in user-facing strings (error messages, banners, labels). Use regular dashes, commas, or parentheses instead.
+- Avoid em-dashes in user-facing strings (error messages, banners, labels). Use regular dashes, commas, or parentheses instead.
 
 ## CI/CD
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,68 @@
+# Segment Reporting - developer convenience targets.
+#
+# This Makefile only wraps the underlying dotnet/npm/properdocs/script commands;
+# CI (.github/workflows/build.yml) invokes those commands directly, so the
+# Makefile can never silently drift the build. Run `make help` for the list.
+#
+# Bruno API tests, fuzzing, leak detection, and the UAT Emby harness arrive as
+# `make bruno|fuzz|leak-check|uat-up|uat-down` alongside the #106 Phase 2/3 work,
+# so their targets ship with the scripts they drive (not before).
+
+SLN := Segment_Reporting.sln
+NPM_PREFIX := segment_reporting
+
+.DEFAULT_GOAL := help
+
+.PHONY: help restore build build-release test format format-check lint gate \
+        hooks hooks-install docs docs-deps docs-serve screenshots clean
+
+help: ## Show this help
+	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+restore: ## Restore NuGet dependencies
+	dotnet restore $(SLN)
+
+build: ## Build the solution (Debug)
+	dotnet build $(SLN)
+
+build-release: ## Build Release (minifies JS; requires Node)
+	dotnet build $(SLN) --configuration Release
+
+test: ## Run the xUnit test suite
+	dotnet test $(SLN)
+
+format: ## Apply code formatting in place
+	dotnet format $(SLN)
+
+format-check: ## Verify formatting without changes (matches CI)
+	dotnet format $(SLN) --verify-no-changes
+
+lint: ## Lint the page JavaScript
+	npm run lint:js --prefix $(NPM_PREFIX)
+
+gate: ## Full CI-parity pre-push gate (build + format + lint)
+	bash scripts/pre-push-gate.sh
+
+hooks: ## Verify git hooks are wired to lefthook
+	bash scripts/check-hooks.sh
+
+hooks-install: ## Install the lefthook git hooks
+	npx --prefix $(NPM_PREFIX) lefthook install && node $(NPM_PREFIX)/scripts/fix-hooks.mjs
+
+docs-deps: ## Install the docs toolchain (ProperDocs, see dev-requirements.txt)
+	pip install -r dev-requirements.txt
+
+docs: ## Build the docs site (strict)
+	properdocs build --strict
+
+docs-serve: ## Serve the docs locally with live reload
+	properdocs serve
+
+screenshots: ## Capture + anonymize page screenshots (needs running Emby + .env)
+	node scripts/capture-screenshots.mjs
+
+clean: ## Remove build output and the generated docs site
+	dotnet clean $(SLN) || true
+	find . -type d \( -name bin -o -name obj \) -exec rm -rf {} + 2>/dev/null || true
+	rm -rf site

--- a/Segment_Reporting.sln
+++ b/Segment_Reporting.sln
@@ -1,22 +1,54 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "segment_reporting", "segment_reporting\segment_reporting.csproj", "{CE037F70-9293-6E1D-56A0-3220BF410CC5}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "segment_reporting.Tests", "tests\segment_reporting.Tests\segment_reporting.Tests.csproj", "{2E375AB5-38A1-4569-92DB-D8EBF2112DE3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CE037F70-9293-6E1D-56A0-3220BF410CC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CE037F70-9293-6E1D-56A0-3220BF410CC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE037F70-9293-6E1D-56A0-3220BF410CC5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CE037F70-9293-6E1D-56A0-3220BF410CC5}.Debug|x64.Build.0 = Debug|Any CPU
+		{CE037F70-9293-6E1D-56A0-3220BF410CC5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CE037F70-9293-6E1D-56A0-3220BF410CC5}.Debug|x86.Build.0 = Debug|Any CPU
 		{CE037F70-9293-6E1D-56A0-3220BF410CC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CE037F70-9293-6E1D-56A0-3220BF410CC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE037F70-9293-6E1D-56A0-3220BF410CC5}.Release|x64.ActiveCfg = Release|Any CPU
+		{CE037F70-9293-6E1D-56A0-3220BF410CC5}.Release|x64.Build.0 = Release|Any CPU
+		{CE037F70-9293-6E1D-56A0-3220BF410CC5}.Release|x86.ActiveCfg = Release|Any CPU
+		{CE037F70-9293-6E1D-56A0-3220BF410CC5}.Release|x86.Build.0 = Release|Any CPU
+		{2E375AB5-38A1-4569-92DB-D8EBF2112DE3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E375AB5-38A1-4569-92DB-D8EBF2112DE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E375AB5-38A1-4569-92DB-D8EBF2112DE3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2E375AB5-38A1-4569-92DB-D8EBF2112DE3}.Debug|x64.Build.0 = Debug|Any CPU
+		{2E375AB5-38A1-4569-92DB-D8EBF2112DE3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2E375AB5-38A1-4569-92DB-D8EBF2112DE3}.Debug|x86.Build.0 = Debug|Any CPU
+		{2E375AB5-38A1-4569-92DB-D8EBF2112DE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E375AB5-38A1-4569-92DB-D8EBF2112DE3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E375AB5-38A1-4569-92DB-D8EBF2112DE3}.Release|x64.ActiveCfg = Release|Any CPU
+		{2E375AB5-38A1-4569-92DB-D8EBF2112DE3}.Release|x64.Build.0 = Release|Any CPU
+		{2E375AB5-38A1-4569-92DB-D8EBF2112DE3}.Release|x86.ActiveCfg = Release|Any CPU
+		{2E375AB5-38A1-4569-92DB-D8EBF2112DE3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{2E375AB5-38A1-4569-92DB-D8EBF2112DE3} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3B3045A7-4460-4420-A40F-49BDD4A06BD4}

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -1823,7 +1823,7 @@ A SQL editor with a visual query builder and saved query management.
 - Save / Delete / Overwrite saved queries
 - Query execution with results displayed in a dynamic table
 - Per-row **Actions** dropdown (Edit, Delete submenu, Set Credits to End,
-  Detect Credits) — shown whenever `ItemId` is present in the result columns
+  Detect Credits) - shown whenever `ItemId` is present in the result columns
 - Tick columns automatically formatted as `HH:MM:SS.fff`
 - CSV export of query results
 - Clear button to reset the interface
@@ -2000,9 +2000,11 @@ branches. Runs on `ubuntu-latest`.
 6. **Restore dependencies** -- `dotnet restore Segment_Reporting.sln`
 7. **Build with analyzers** -- `dotnet build` with `-warnaserror` so any
    StyleCop or analyzer warning fails the build
-8. **Check code formatting** -- `dotnet format --verify-no-changes` ensures
+8. **Run tests** -- `dotnet test Segment_Reporting.sln --configuration Release
+   --no-build` runs the xUnit suite (see the Testing section)
+9. **Check code formatting** -- `dotnet format --verify-no-changes` ensures
    code style matches `.editorconfig` rules
-9. **Upload artifact** -- the compiled DLL is uploaded as a build artifact
+10. **Upload artifact** -- the compiled DLL is uploaded as a build artifact
 
 **Key point:** JS minification happens *before* `dotnet build` so the minified
 files are what gets compiled into the DLL as embedded resources. The MSBuild
@@ -2151,10 +2153,24 @@ Follow these steps to create a release:
 
 ## 8. Testing
 
-There are no automated unit tests -- Emby plugins require a running server
-instance with loaded libraries to exercise the code paths. Testing is done
-manually against a live Emby server using the Bruno API test collection and
-direct UI interaction.
+Pure logic (the custom-query security validators and marker-type helpers) is
+covered by an xUnit unit-test project; everything that needs a live Emby server
+(sync, write-through, UI) is still verified manually against a running server
+using the Bruno API test collection and direct UI interaction.
+
+### Unit Tests (xUnit)
+
+The `tests/segment_reporting.Tests` project covers logic that does not need a
+running Emby server: the custom-query validators (`ContainsDangerousKeyword`,
+`IsAllowedPragma`, exposed as `internal` via `InternalsVisibleTo`) and
+`MarkerTypes`. Run them with `make test` or `dotnet test Segment_Reporting.sln`.
+
+The project targets `net8.0` to match the CI SDK; `<RollForward>Major</RollForward>`
+lets the test host run on a newer locally-installed runtime when 8.0 is absent.
+CI runs them as a dedicated step in the build job (see the CI/CD Pipeline section).
+
+Future work (issue #106) adds repository/migration tests, SharpFuzz fuzz targets
+for the query parser, the Threading.Analyzers, and a Dockerized UAT Emby harness.
 
 ### Manual Testing Workflow
 

--- a/segment_reporting/Data/MarkerTypes.cs
+++ b/segment_reporting/Data/MarkerTypes.cs
@@ -16,11 +16,21 @@ namespace segment_reporting.Data
 
         public static string GetColumnName(string markerType)
         {
-            if (!Valid.Contains(markerType))
+            // Normalize to the canonical constant so the column name is stable
+            // regardless of the caller's casing (e.g. "introstart" -> "IntroStartTicks").
+            if (string.Equals(markerType, IntroStart, StringComparison.OrdinalIgnoreCase))
             {
-                throw new ArgumentException("Unknown marker type: " + markerType, nameof(markerType));
+                return IntroStart + "Ticks";
             }
-            return markerType + "Ticks";
+            if (string.Equals(markerType, IntroEnd, StringComparison.OrdinalIgnoreCase))
+            {
+                return IntroEnd + "Ticks";
+            }
+            if (string.Equals(markerType, CreditsStart, StringComparison.OrdinalIgnoreCase))
+            {
+                return CreditsStart + "Ticks";
+            }
+            throw new ArgumentException("Unknown marker type: " + markerType, nameof(markerType));
         }
 
         public static bool IsIntroType(string markerType)

--- a/segment_reporting/Data/SegmentRepository.cs
+++ b/segment_reporting/Data/SegmentRepository.cs
@@ -711,7 +711,7 @@ namespace segment_reporting.Data
             string sql;
             if (isNullSeason)
             {
-                // Episodes with no season parent — scope to series when available
+                // Episodes with no season parent - scope to series when available
                 sql = !string.IsNullOrEmpty(seriesId)
                     ? "SELECT * FROM MediaSegments WHERE SeasonId IS NULL AND SeriesId = @SeriesId AND ItemType = 'Episode' ORDER BY EpisodeNumber"
                     : "SELECT * FROM MediaSegments WHERE SeasonId IS NULL AND ItemType = 'Episode' ORDER BY EpisodeNumber";
@@ -804,7 +804,7 @@ namespace segment_reporting.Data
 
                 if (MarkerTypes.IsIntroType(markerType))
                 {
-                    string otherColumn = markerType == MarkerTypes.IntroStart
+                    string otherColumn = string.Equals(markerType, MarkerTypes.IntroStart, StringComparison.OrdinalIgnoreCase)
                         ? MarkerTypes.GetColumnName(MarkerTypes.IntroEnd)
                         : MarkerTypes.GetColumnName(MarkerTypes.IntroStart);
                     sql += ", HasIntro = CASE WHEN " + otherColumn + " IS NOT NULL THEN 1 ELSE 0 END";
@@ -1020,7 +1020,7 @@ namespace segment_reporting.Data
             "foreign_key_list", "compile_options", "integrity_check"
         };
 
-        private static bool ContainsDangerousKeyword(string sql)
+        internal static bool ContainsDangerousKeyword(string sql)
         {
             if (sql.Contains(";"))
             {
@@ -1049,7 +1049,7 @@ namespace segment_reporting.Data
             return false;
         }
 
-        private static bool IsAllowedPragma(string trimmedSql)
+        internal static bool IsAllowedPragma(string trimmedSql)
         {
             // Extract pragma name from "PRAGMA [schema.]name" or "PRAGMA [schema.]name(...)"
             var afterPragma = trimmedSql.Substring(6).TrimStart();

--- a/segment_reporting/Properties/AssemblyInfo.cs
+++ b/segment_reporting/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -17,6 +18,9 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+// Expose internal members (e.g. custom-query validators) to the unit test project.
+[assembly: InternalsVisibleTo("segment_reporting.Tests")]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e921fa9a-8b1c-4d5e-9f2a-3c7b6d8e4a1f")]

--- a/tests/segment_reporting.Tests/CustomQueryValidationTests.cs
+++ b/tests/segment_reporting.Tests/CustomQueryValidationTests.cs
@@ -1,0 +1,50 @@
+using segment_reporting.Data;
+using Xunit;
+
+namespace segment_reporting.Tests
+{
+    // Exercises the custom-query security boundary in isolation. These are the
+    // gate that protects the user-facing SQL console: only read-only SELECT /
+    // PRAGMA / EXPLAIN may run, with no statement chaining or extension loading.
+    public class CustomQueryValidationTests
+    {
+        [Theory]
+        [InlineData("SELECT * FROM MediaSegments")]
+        [InlineData("SELECT IntroStartTicks FROM MediaSegments WHERE ItemType = 'Episode'")]
+        [InlineData("SELECT * FROM attachments")]
+        [InlineData("EXPLAIN QUERY PLAN SELECT 1")]
+        public void ContainsDangerousKeyword_AllowsSafeQueries(string sql)
+        {
+            Assert.False(SegmentRepository.ContainsDangerousKeyword(sql));
+        }
+
+        [Theory]
+        [InlineData("SELECT 1; DROP TABLE MediaSegments")]
+        [InlineData("ATTACH DATABASE 'evil.db' AS evil")]
+        [InlineData("SELECT load_extension('x.so')")]
+        [InlineData("SELECT * FROM t WHERE x = load_extension('a')")]
+        public void ContainsDangerousKeyword_BlocksChainingAndExtensions(string sql)
+        {
+            Assert.True(SegmentRepository.ContainsDangerousKeyword(sql));
+        }
+
+        [Theory]
+        [InlineData("PRAGMA table_info(MediaSegments)")]
+        [InlineData("PRAGMA main.table_info(MediaSegments)")]
+        [InlineData("PRAGMA integrity_check")]
+        [InlineData("pragma Table_Info(MediaSegments)")]
+        public void IsAllowedPragma_AllowsReadOnlyPragmas(string sql)
+        {
+            Assert.True(SegmentRepository.IsAllowedPragma(sql));
+        }
+
+        [Theory]
+        [InlineData("PRAGMA user_version")]
+        [InlineData("PRAGMA writable_schema = ON")]
+        [InlineData("PRAGMA journal_mode = WAL")]
+        public void IsAllowedPragma_RejectsWritableAndUnknownPragmas(string sql)
+        {
+            Assert.False(SegmentRepository.IsAllowedPragma(sql));
+        }
+    }
+}

--- a/tests/segment_reporting.Tests/MarkerTypesTests.cs
+++ b/tests/segment_reporting.Tests/MarkerTypesTests.cs
@@ -1,0 +1,36 @@
+using System;
+using segment_reporting.Data;
+using Xunit;
+
+namespace segment_reporting.Tests
+{
+    public class MarkerTypesTests
+    {
+        [Theory]
+        [InlineData("IntroStart", "IntroStartTicks")]
+        [InlineData("IntroEnd", "IntroEndTicks")]
+        [InlineData("CreditsStart", "CreditsStartTicks")]
+        [InlineData("introstart", "IntroStartTicks")]
+        public void GetColumnName_NormalizesAndAppendsTicks_ForValidTypes(string markerType, string expected)
+        {
+            Assert.Equal(expected, MarkerTypes.GetColumnName(markerType));
+        }
+
+        [Fact]
+        public void GetColumnName_Throws_ForUnknownType()
+        {
+            Assert.Throws<ArgumentException>(() => MarkerTypes.GetColumnName("NotAMarker"));
+        }
+
+        [Theory]
+        [InlineData("IntroStart", true)]
+        [InlineData("IntroEnd", true)]
+        [InlineData("introstart", true)]
+        [InlineData("CreditsStart", false)]
+        [InlineData("Bogus", false)]
+        public void IsIntroType_RecognizesIntroMarkers(string markerType, bool expected)
+        {
+            Assert.Equal(expected, MarkerTypes.IsIntroType(markerType));
+        }
+    }
+}

--- a/tests/segment_reporting.Tests/segment_reporting.Tests.csproj
+++ b/tests/segment_reporting.Tests/segment_reporting.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Matches the CI SDK (actions/setup-dotnet 8.0.x). RollForward lets the
+         net8.0 test host run on a newer local runtime (e.g. .NET 10) when 8.0
+         is not installed, so tests are runnable locally and in CI alike. -->
+    <TargetFramework>net8.0</TargetFramework>
+    <RollForward>Major</RollForward>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+    <!-- The plugin's strict StyleCop/Roslynator analyzer set is not applied to
+         test code; keep test projects focused on behavior, not house style. -->
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\segment_reporting\segment_reporting.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Part of #106 (testing infrastructure) - **Phase 1**. Establishes the unit-test foundation and a developer convenience Makefile.

## What's included

**Unit tests (`tests/segment_reporting.Tests`, xUnit)**
- Covers the custom-query security boundary: `ContainsDangerousKeyword` and `IsAllowedPragma` (exposed as `internal` via `[InternalsVisibleTo]`), plus `MarkerTypes`. 25 tests.
- Targets `net8.0` to match the CI SDK; `<RollForward>Major</RollForward>` lets the test host run on a newer locally-installed runtime when 8.0 is absent.
- Wired into the CI build job as a dedicated `dotnet test` step.

**Developer Makefile**
- `make help` lists `build/test/format/lint/gate/hooks/docs/docs-serve/screenshots/clean`. Wraps the existing dotnet/npm/properdocs/script commands only - CI invokes those directly, so the Makefile cannot drift the build.
- `bruno`/`fuzz`/`leak-check`/`uat-up`/`uat-down` targets are intentionally deferred to Phase 2/3 so they ship with the scripts they drive (no dangling targets).
- `.editorconfig`: tab-indent rule for Makefiles.

**Housekeeping**
- gitignore `.env`/`.env.*` and add `.env.example` (local Emby creds for UAT/screenshots).
- CLAUDE.md: correct the Emby SDK version (`4.9.x`, `netstandard2.0`) and note `make help`.
- DEVELOPER.md: Testing + CI/CD sections reflect the xUnit suite and the new CI test step.

## Not in scope (follow-up #106 phases)
- Phase 2: Dockerized UAT Emby harness + Bruno assertions.
- Phase 3: concurrency stress test for `SegmentRepository`.
- SharpFuzz fuzz targets for the query parser; `Microsoft.VisualStudio.Threading.Analyzers`.
- JS helpers (tick/hex/escape) are JS-only - a separate Vitest track if desired.

## Verification
- `dotnet build -warnaserror` clean, `dotnet test` 25/25 pass, `dotnet format --verify-no-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)