### PR TITLE
style: remove em-dashes from user-facing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,30 +8,30 @@ Documentation site: **https://sydlexius.github.io/Segment_Reporting/** (User Gui
 
 ### Reporting & Navigation
 
-- **Interactive Dashboard** — Overview charts showing segment coverage per library, with breadcrumb drill-down navigation into libraries, series, and episodes
-- **Library Browsing** — Browse series and movies with segment coverage stats, sortable columns, and filtering by segment status (missing intros, missing credits, has intro, has credits, etc.)
-- **Series Detail** — Season/episode grid with per-season intro and credits coverage percentages, expandable accordions, and search
-- **Movie Support** — Movie libraries display a flat table with inline segment timestamps; mixed libraries show both series and movies. Note: there is currently no automated detection mechanism for movie intros or credits, so movie and mixed library support is primarily reporting-only unless you add markers manually
+- **Interactive Dashboard** - Overview charts showing segment coverage per library, with breadcrumb drill-down navigation into libraries, series, and episodes
+- **Library Browsing** - Browse series and movies with segment coverage stats, sortable columns, and filtering by segment status (missing intros, missing credits, has intro, has credits, etc.)
+- **Series Detail** - Season/episode grid with per-season intro and credits coverage percentages, expandable accordions, and search
+- **Movie Support** - Movie libraries display a flat table with inline segment timestamps; mixed libraries show both series and movies. Note: there is currently no automated detection mechanism for movie intros or credits, so movie and mixed library support is primarily reporting-only unless you add markers manually
 
 ### Editing & Bulk Operations
 
-- **Inline Editing** — Edit intro/credits timestamps directly in any table view (library, series, or query results) via a unified Actions dropdown menu
-- **Bulk Operations** — Copy intros, credits, or both across episodes (type-selective), bulk delete intros or credits, and set credits-to-end in bulk
-- **EmbyCredits Integration** — When the [EmbyCredits](https://github.com/faush01/EmbyCredits) plugin is installed, "Detect Credits" buttons appear on the dashboard, library, series, and custom query pages to trigger credits detection directly
+- **Inline Editing** - Edit intro/credits timestamps directly in any table view (library, series, or query results) via a unified Actions dropdown menu
+- **Bulk Operations** - Copy intros, credits, or both across episodes (type-selective), bulk delete intros or credits, and set credits-to-end in bulk
+- **EmbyCredits Integration** - When the [EmbyCredits](https://github.com/faush01/EmbyCredits) plugin is installed, "Detect Credits" buttons appear on the dashboard, library, series, and custom query pages to trigger credits detection directly
 
 ### Custom Query
 
-- **Visual Query Builder** — Point-and-click query builder with field/operator selection, condition groups, and drag-to-reorder column pills
-- **Autocomplete & Multi-Value Selection** — Fields like Series Name, Library Name, and Item Type offer autocomplete suggestions from your library; use "is any of" / "is none of" operators for multi-value pill selection with `IN`/`NOT IN` SQL generation
-- **Interactive Results** — Query results support inline editing, row selection with checkboxes, bulk actions, clickable playback links on timestamps, and CSV export
-- **Saved Queries** — Save, load, and delete named queries; the visual builder fully round-trips `IN`/`NOT IN` clauses
+- **Visual Query Builder** - Point-and-click query builder with field/operator selection, condition groups, and drag-to-reorder column pills
+- **Autocomplete & Multi-Value Selection** - Fields like Series Name, Library Name, and Item Type offer autocomplete suggestions from your library; use "is any of" / "is none of" operators for multi-value pill selection with `IN`/`NOT IN` SQL generation
+- **Interactive Results** - Query results support inline editing, row selection with checkboxes, bulk actions, clickable playback links on timestamps, and CSV export
+- **Saved Queries** - Save, load, and delete named queries; the visual builder fully round-trips `IN`/`NOT IN` clauses
 
 ### Settings & Maintenance
 
-- **Display Preferences** — Choose from five named, theme-aware chart color palettes (Green, Blue, Red, Pink, Purple), plus Auto (accent-matched) and Custom colors; toggle gridlines and alternating row colors, and hide specific libraries from the dashboard
-- **Scheduled Sync** — Automatic daily sync with your Emby server (configurable via Emby's Scheduled Tasks)
-- **Cache Maintenance** — Weekly VACUUM task, on-demand Vacuum button, force rescan, and sync status display
-- **About Page** — Plugin version, acknowledgements, Emby Forums link, and API endpoint reference
+- **Display Preferences** - Choose from five named, theme-aware chart color palettes (Green, Blue, Red, Pink, Purple), plus Auto (accent-matched) and Custom colors; toggle gridlines and alternating row colors, and hide specific libraries from the dashboard
+- **Scheduled Sync** - Automatic daily sync with your Emby server (configurable via Emby's Scheduled Tasks)
+- **Cache Maintenance** - Weekly VACUUM task, on-demand Vacuum button, force rescan, and sync status display
+- **About Page** - Plugin version, acknowledgements, Emby Forums link, and API endpoint reference
 
 ## Screenshots
 
@@ -55,8 +55,8 @@ See the **[User Guide](docs/USER_GUIDE.md)** for a full walkthrough with all scr
 
 The plugin integrates with Emby's built-in Scheduled Tasks system:
 
-- **Sync Segments** — Default: Daily at 2:00 AM (crawls all libraries and syncs segment data to the cache)
-- **Clean Segment DB** — Default: Weekly on Sunday at 3:00 AM (VACUUM and health check)
+- **Sync Segments** - Default: Daily at 2:00 AM (crawls all libraries and syncs segment data to the cache)
+- **Clean Segment DB** - Default: Weekly on Sunday at 3:00 AM (VACUUM and health check)
 
 From the plugin Settings page you can:
 
@@ -85,15 +85,15 @@ The compiled DLL will be in `bin/Release/`.
 
 ### Dependencies
 
-- `mediabrowser.server.core` (4.9.*) — Emby server SDK
-- `SQLitePCL.pretty.core` (1.2.2) — SQLite database wrapper
-- `System.Memory` (4.6.3) — Memory utilities
+- `mediabrowser.server.core` (4.9.*) - Emby server SDK
+- `SQLitePCL.pretty.core` (1.2.2) - SQLite database wrapper
+- `System.Memory` (4.6.3) - Memory utilities
 
 ## Supported Segment Types
 
-- `IntroStart` — Intro marker start timestamp
-- `IntroEnd` — Intro marker end timestamp
-- `CreditsStart` — Credits marker start timestamp
+- `IntroStart` - Intro marker start timestamp
+- `IntroEnd` - Intro marker end timestamp
+- `CreditsStart` - Credits marker start timestamp
 
 These are the three marker types that Emby currently supports. Other segment types such as recaps, previews, commercials, and mid/post-credit scenes are not supported by Emby's chapter system and therefore cannot be tracked by this plugin.
 
@@ -115,7 +115,7 @@ This project is licensed under **GNU General Public License v3.0** (GPL-3.0). Se
 
 Segment Reporting is built on architectural patterns and code references from the following GPL-3.0 licensed projects by [faush01](https://github.com/faush01):
 
-- **[playback_reporting](https://github.com/faush01/playback_reporting)** — Emby plugin for media playback analytics. Used as the primary architectural template for:
+- **[playback_reporting](https://github.com/faush01/playback_reporting)** - Emby plugin for media playback analytics. Used as the primary architectural template for:
   - Plugin scaffolding and configuration patterns
   - SQLite data layer and query patterns
   - REST API structure and authentication
@@ -123,7 +123,7 @@ Segment Reporting is built on architectural patterns and code references from th
   - Scheduled task registration and execution
   - Chart library integration and visualization patterns
 
-- **[ChapterApi](https://github.com/faush01/ChapterApi)** — Emby plugin providing a reference implementation of Emby's media segment APIs. Used as the reference for:
+- **[ChapterApi](https://github.com/faush01/ChapterApi)** - Emby plugin providing a reference implementation of Emby's media segment APIs. Used as the reference for:
   - `IItemRepository.GetChapters()` and `SaveChapters()` APIs
   - Chapter/marker type definitions (`MarkerType` enum, `ChapterInfo` model)
   - Write-through patterns for persisting chapters to Emby
@@ -132,10 +132,10 @@ Both projects are licensed under GPL-3.0 and have been instrumental in understan
 
 ## Documentation
 
-- **[User Guide](docs/USER_GUIDE.md)** — Full walkthrough with screenshots
-- **[Developer Guide](docs/DEVELOPER.md)** — Architecture, data models, API specs
+- **[User Guide](docs/USER_GUIDE.md)** - Full walkthrough with screenshots
+- **[Developer Guide](docs/DEVELOPER.md)** - Architecture, data models, API specs
 
 ## Support
 
-- **Emby Forums** — [Segment Reporting discussion thread](https://emby.media/community/index.php?/topic/146268-segment-reporting-plugin/)
-- **GitHub** — [Issues and feature requests](../../issues)
+- **Emby Forums** - [Segment Reporting discussion thread](https://emby.media/community/index.php?/topic/146268-segment-reporting-plugin/)
+- **GitHub** - [Issues and feature requests](../../issues)

--- a/docs/plans/issue-execution-guide.md
+++ b/docs/plans/issue-execution-guide.md
@@ -16,53 +16,53 @@ Read docs/plans/issue-execution-guide.md and execute the next unchecked session.
 
 ## Progress Tracker
 
-### Phase 1 — Quick Wins (safety fixes + small bundled fixes)
+### Phase 1 - Quick Wins (safety fixes + small bundled fixes)
 
 Small, focused changes that reduce risk and clean up low-hanging fruit. Do these first while the codebase is stable.
 
-- [x] **Session 1A** — #64 — Custom query SQL hardening (Small)
-- [x] **Session 1B** — #65 — MarkerTypes.GetColumnName validation (Tiny)
-- [x] **Session 1C** — #66 — Dispose lock ordering (Small)
-- [x] **Session 1D** — #71 + #74 + #75 — Three small JS fixes in one commit (Tiny bundle)
-- [x] **Session 1E** — #72 + #73 — Two small C# fixes in one commit (Tiny bundle)
+- [x] **Session 1A** - #64 - Custom query SQL hardening (Small)
+- [x] **Session 1B** - #65 - MarkerTypes.GetColumnName validation (Tiny)
+- [x] **Session 1C** - #66 - Dispose lock ordering (Small)
+- [x] **Session 1D** - #71 + #74 + #75 - Three small JS fixes in one commit (Tiny bundle)
+- [x] **Session 1E** - #72 + #73 - Two small C# fixes in one commit (Tiny bundle)
 
-### Phase 2 — Tooling
+### Phase 2 - Tooling
 
 Set up analyzers and linting so they catch problems during all subsequent work.
 
-- [x] **Session 2A** — #76 Milestone 1 — C# analyzers: Roslynator, IDisposableAnalyzers (Medium)
-- [x] **Session 2B** — #76 Milestone 2 — ESLint for JavaScript (Medium)
-- [x] **Session 2C** — #76 Milestone 3 — Lefthook pre-commit hooks (Small)
+- [x] **Session 2A** - #76 Milestone 1 - C# analyzers: Roslynator, IDisposableAnalyzers (Medium)
+- [x] **Session 2B** - #76 Milestone 2 - ESLint for JavaScript (Medium)
+- [x] **Session 2C** - #76 Milestone 3 - Lefthook pre-commit hooks (Small)
 
-### Phase 3 — Backend Refactors
+### Phase 3 - Backend Refactors
 
 Clean up C# code while no frontend work is in flight.
 
-- [x] **Session 3A** — #68 — Extract bulk operation helper (Small-Medium) `[plan first]`
-- [x] **Session 3B** — #60 — Drop LastSyncDate column migration (Small-Medium)
+- [x] **Session 3A** - #68 - Extract bulk operation helper (Small-Medium) `[plan first]`
+- [x] **Session 3B** - #60 - Drop LastSyncDate column migration (Small-Medium)
 
-### Phase 4 — Frontend Refactors
+### Phase 4 - Frontend Refactors
 
 Large JS refactors that touch shared files. Do these before feature work to avoid merge conflicts.
 
-- [x] **Session 4A** — #67 Milestones 1-2 — Design + implement shared inline editor (Medium) `[plan first]`
-- [x] **Session 4B** — #67 Milestones 3-5 — Migrate all 3 pages to shared editor (Medium-Large) `[plan first]`
-- [x] **Session 4C** — #70 — Debounce/guard buttons across pages (Small-Medium)
-- [x] **Session 4D** — #69 — Movie delete menu theme colors (Small)
+- [x] **Session 4A** - #67 Milestones 1-2 - Design + implement shared inline editor (Medium) `[plan first]`
+- [x] **Session 4B** - #67 Milestones 3-5 - Migrate all 3 pages to shared editor (Medium-Large) `[plan first]`
+- [x] **Session 4C** - #70 - Debounce/guard buttons across pages (Small-Medium)
+- [x] **Session 4D** - #69 - Movie delete menu theme colors (Small)
 
-### Phase 5 — Features
+### Phase 5 - Features
 
 Build new functionality on the cleaned-up codebase.
 
-- [x] **Session 5A** — #61 — Dashboard coverage split + Detect button label (Medium)
-- [x] **Session 5B** — #63 — Season-level Actions dropdown (Medium) `[plan first]`
-- [x] **Session 5C** — #78 — Extend season Actions with bulk operations (Medium) `[plan first]`
+- [x] **Session 5A** - #61 - Dashboard coverage split + Detect button label (Medium)
+- [x] **Session 5B** - #63 - Season-level Actions dropdown (Medium) `[plan first]`
+- [x] **Session 5C** - #78 - Extend season Actions with bulk operations (Medium) `[plan first]`
 
-### Phase 6 — Documentation (last)
+### Phase 6 - Documentation (last)
 
 Screenshots and docs after all UI changes are settled.
 
-- [ ] **Session 6A** — #62 — User Guide screenshots — do AFTER all UI changes (Medium)
+- [ ] **Session 6A** - #62 - User Guide screenshots - do AFTER all UI changes (Medium)
 
 ---
 
@@ -72,7 +72,7 @@ Copy-paste these into Claude Code at the start of each session. Each prompt is s
 
 ---
 
-### Session 1A — Custom Query SQL Hardening (#64)
+### Session 1A - Custom Query SQL Hardening (#64)
 
 ```
 Implement issue #64: Harden the custom query endpoint against SQL abuse.
@@ -93,7 +93,7 @@ When done, mark Session 1A as [x] in docs/plans/issue-execution-guide.md and inc
 
 ---
 
-### Session 1B — MarkerTypes.GetColumnName Validation (#65)
+### Session 1B - MarkerTypes.GetColumnName Validation (#65)
 
 ```
 Implement issue #65: Add input validation to MarkerTypes.GetColumnName().
@@ -104,14 +104,14 @@ Currently it blindly appends "Ticks" to any input, and the result gets interpola
 - If the markerType is not in MarkerTypes.Valid, throw ArgumentException
 - This makes the method self-validating so callers can't accidentally bypass the check
 
-This is a tiny change — just add the guard clause. Bump revision, build to verify.
+This is a tiny change - just add the guard clause. Bump revision, build to verify.
 
 When done, mark Session 1B as [x] in docs/plans/issue-execution-guide.md and include the guide in the commit.
 ```
 
 ---
 
-### Session 1C — Dispose Lock Ordering (#66)
+### Session 1C - Dispose Lock Ordering (#66)
 
 ```
 Implement issue #66: Fix the potential deadlock in SegmentRepository.Dispose() lock ordering.
@@ -134,14 +134,14 @@ When done, mark Session 1C as [x] in docs/plans/issue-execution-guide.md and inc
 
 ---
 
-### Session 1D — Small JS Fixes Bundle (#71 + #74 + #75)
+### Session 1D - Small JS Fixes Bundle (#71 + #74 + #75)
 
 ```
 Implement three small JS fixes in one commit, covering issues #71, #74, and #75.
 
 Fix 1 (#71): In segment_reporting/Pages/segment_series.js around line 260-273, wrap seasonLabel in helpers.escHtml() before inserting into innerHTML. The season.SeasonName value is currently unescaped.
 
-Fix 2 (#74): In segment_reporting/Pages/segment_reporting_helpers.js, remove the clearNavParams function and its export from getSegmentReportingHelpers() — it's never called by any page. Also in segment_reporting/Pages/segment_custom_query.js line 2, change the copyright year from 2024 to 2026.
+Fix 2 (#74): In segment_reporting/Pages/segment_reporting_helpers.js, remove the clearNavParams function and its export from getSegmentReportingHelpers() - it's never called by any page. Also in segment_reporting/Pages/segment_custom_query.js line 2, change the copyright year from 2024 to 2026.
 
 Fix 3 (#75): In segment_reporting/Pages/segment_custom_query.js around line 2349-2360, add URL.revokeObjectURL(url) after the CSV download link click. Use setTimeout with ~1000ms delay so the browser finishes the download first.
 
@@ -152,7 +152,7 @@ When done, mark Session 1D as [x] in docs/plans/issue-execution-guide.md and inc
 
 ---
 
-### Session 1E — Small C# Fixes Bundle (#72 + #73)
+### Session 1E - Small C# Fixes Bundle (#72 + #73)
 
 ```
 Implement two small C# fixes in one commit, covering issues #72 and #73.
@@ -168,7 +168,7 @@ When done, mark Session 1E as [x] in docs/plans/issue-execution-guide.md and inc
 
 ---
 
-### Session 2A — C# Analyzers (#76 Milestone 1)
+### Session 2A - C# Analyzers (#76 Milestone 1)
 
 ```
 Implement issue #76, Milestone 1: Add C# analyzer enhancements.
@@ -180,7 +180,7 @@ Changes to segment_reporting/segment_reporting.csproj:
 
 Then:
 1. Build: dotnet build segment_reporting/segment_reporting.csproj -c Release
-2. Triage all new warnings — for each:
+2. Triage all new warnings - for each:
    - If it's a real issue: fix it in this same session
    - If it's a false positive or intentional pattern: suppress in .editorconfig with a comment explaining why
 3. The build uses -warnaserror in CI, so all warnings must be either fixed or suppressed
@@ -193,7 +193,7 @@ When done, mark Session 2A as [x] in docs/plans/issue-execution-guide.md and inc
 
 ---
 
-### Session 2B — ESLint for JavaScript (#76 Milestone 2)
+### Session 2B - ESLint for JavaScript (#76 Milestone 2)
 
 ```
 Implement issue #76, Milestone 2: Add ESLint for JavaScript.
@@ -225,7 +225,7 @@ When done, mark Session 2B as [x] in docs/plans/issue-execution-guide.md and inc
 
 ---
 
-### Session 2C — Lefthook Pre-commit Hooks (#76 Milestone 3)
+### Session 2C - Lefthook Pre-commit Hooks (#76 Milestone 3)
 
 ```
 Implement issue #76, Milestone 3: Add Lefthook pre-commit hooks.
@@ -251,16 +251,16 @@ Implement issue #76, Milestone 3: Add Lefthook pre-commit hooks.
 3. Update docs/DEVELOPER.md to document the pre-commit hook setup:
    - How to install (lefthook install after cloning)
    - What it checks (format, lint, whitespace, conflict markers)
-   - How to bypass if needed (git commit --no-verify — but discouraged)
+   - How to bypass if needed (git commit --no-verify - but discouraged)
 
-No revision bump needed — this is infrastructure only, no code changes.
+No revision bump needed - this is infrastructure only, no code changes.
 
 When done, mark Session 2C as [x] in docs/plans/issue-execution-guide.md and include the guide in the commit.
 ```
 
 ---
 
-### Session 3A — Extract Bulk Operation Logic (#68)
+### Session 3A - Extract Bulk Operation Logic (#68)
 
 ```
 Implement issue #68: Extract shared bulk operation logic in the API.
@@ -284,7 +284,7 @@ When done, mark Session 3A as [x] in docs/plans/issue-execution-guide.md and inc
 
 ---
 
-### Session 3B — Drop LastSyncDate Column (#60)
+### Session 3B - Drop LastSyncDate Column (#60)
 
 ```
 Implement issue #60: Drop the LastSyncDate column from MediaSegments.
@@ -293,7 +293,7 @@ File: segment_reporting/Data/SegmentRepository.cs, in the migration/initializati
 
 In CheckMigration() or the initialization path:
 1. Try: ALTER TABLE MediaSegments DROP COLUMN LastSyncDate
-2. Catch: On failure (older SQLite without DROP COLUMN support), fall back to UPDATE MediaSegments SET LastSyncDate = NULL — this nulls out the data even if the column can't be dropped
+2. Catch: On failure (older SQLite without DROP COLUMN support), fall back to UPDATE MediaSegments SET LastSyncDate = NULL - this nulls out the data even if the column can't be dropped
 
 Also:
 - Remove any code that reads or writes the LastSyncDate column (grep for "LastSyncDate" across all files)
@@ -309,15 +309,15 @@ When done, mark Session 3B as [x] in docs/plans/issue-execution-guide.md and inc
 
 ---
 
-### Session 4A — Inline Editor: Design + Implement (#67 Milestones 1-2)
+### Session 4A - Inline Editor: Design + Implement (#67 Milestones 1-2)
 
 ```
 Implement issue #67, Milestones 1 and 2: Design and implement the shared inline editing module.
 
 First, READ the three existing inline editing implementations to understand the common pattern:
-- segment_reporting/Pages/segment_series.js — episode editing
-- segment_reporting/Pages/segment_library.js — movie editing
-- segment_reporting/Pages/segment_custom_query.js — query result editing
+- segment_reporting/Pages/segment_series.js - episode editing
+- segment_reporting/Pages/segment_library.js - movie editing
+- segment_reporting/Pages/segment_custom_query.js - query result editing
 
 Identify the common lifecycle (start edit → show inputs → save → API call → refresh) and the per-page variations (column definitions, API endpoints, validation rules, post-save behavior).
 
@@ -326,7 +326,7 @@ Then implement a shared createInlineEditor() function in segment_reporting/Pages
 - Handles: input creation from cell values, value extraction, time-tick validation, API save with error handling, cancel/restore, loading state
 - Provides hooks for per-page custom behavior
 
-Do NOT migrate the pages yet — just add the new shared function alongside the existing code. The migrations happen in a separate session.
+Do NOT migrate the pages yet - just add the new shared function alongside the existing code. The migrations happen in a separate session.
 
 Bump revision, build to verify.
 
@@ -335,18 +335,18 @@ When done, mark Session 4A as [x] in docs/plans/issue-execution-guide.md and inc
 
 ---
 
-### Session 4B — Inline Editor: Migrate Pages (#67 Milestones 3-5)
+### Session 4B - Inline Editor: Migrate Pages (#67 Milestones 3-5)
 
 ```
 Implement issue #67, Milestones 3-5: Migrate all three pages to use the shared inline editor.
 
 The shared createInlineEditor() helper was added in the previous session. Now migrate each page:
 
-1. segment_series.js FIRST (most standard pattern) — replace its inline editing code with helpers.createInlineEditor(...) calls. Test: edit an episode's intro/credits timestamps, verify save/cancel/refresh all work, verify no regressions in season expand/collapse.
+1. segment_series.js FIRST (most standard pattern) - replace its inline editing code with helpers.createInlineEditor(...) calls. Test: edit an episode's intro/credits timestamps, verify save/cancel/refresh all work, verify no regressions in season expand/collapse.
 
-2. segment_library.js SECOND — same migration for movie editing. Test: edit a movie's timestamps.
+2. segment_library.js SECOND - same migration for movie editing. Test: edit a movie's timestamps.
 
-3. segment_custom_query.js LAST (most customized — editable columns depend on query results). May need additional config options. Test: run a custom query, edit a result row.
+3. segment_custom_query.js LAST (most customized - editable columns depend on query results). May need additional config options. Test: run a custom query, edit a result row.
 
 After migrating all three, delete the now-dead inline editing code from each page.
 
@@ -357,7 +357,7 @@ When done, mark Session 4B as [x] in docs/plans/issue-execution-guide.md and inc
 
 ---
 
-### Session 4C — Debounce Buttons (#70)
+### Session 4C - Debounce Buttons (#70)
 
 ```
 Implement issue #70: Add debounce/guard to save/delete buttons to prevent double-submission.
@@ -383,7 +383,7 @@ When done, mark Session 4C as [x] in docs/plans/issue-execution-guide.md and inc
 
 ---
 
-### Session 4D — Movie Delete Menu Theme (#69)
+### Session 4D - Movie Delete Menu Theme (#69)
 
 ```
 Implement issue #69: Migrate the movie delete menu to use shared menu infrastructure.
@@ -401,25 +401,25 @@ When done, mark Session 4D as [x] in docs/plans/issue-execution-guide.md and inc
 
 ---
 
-### Session 5A — Dashboard Coverage Split (#61)
+### Session 5A - Dashboard Coverage Split (#61)
 
 ```
 Implement issue #61: Split the Coverage % column by type and clarify the Detect button label.
 
 Files:
-- segment_reporting/Pages/segment_dashboard.js — main changes
-- segment_reporting/Pages/segment_dashboard.html — update table header if needed
+- segment_reporting/Pages/segment_dashboard.js - main changes
+- segment_reporting/Pages/segment_dashboard.html - update table header if needed
 
 Changes:
 1. Replace the single "Coverage" column in the library table with two columns: "Intro %" and "Credits %". Use helpers.percentage(withIntro, totalItems) and helpers.percentage(withCredits, totalItems) respectively.
 
 2. Change the per-library button label from "Detect" to "Detect Credits" to match the global "Detect All Credits" button.
 
-3. Review the stacked bar chart labels — update if they reference a single "Coverage" metric.
+3. Review the stacked bar chart labels - update if they reference a single "Coverage" metric.
 
 Also update:
-- docs/USER_GUIDE.md — Dashboard section to reflect new columns and button label
-- Properties/AssemblyInfo.cs — bump revision (release notes are auto-generated by GitHub from merged PRs; no RELEASE_NOTES.md file)
+- docs/USER_GUIDE.md - Dashboard section to reflect new columns and button label
+- Properties/AssemblyInfo.cs - bump revision (release notes are auto-generated by GitHub from merged PRs; no RELEASE_NOTES.md file)
 
 Build to verify.
 
@@ -428,7 +428,7 @@ When done, mark Session 5A as [x] in docs/plans/issue-execution-guide.md and inc
 
 ---
 
-### Session 5B — Season-Level Actions Dropdown (#63)
+### Session 5B - Season-Level Actions Dropdown (#63)
 
 ```
 Implement issue #63: Replace the season-level Detect button with an Actions dropdown using EmbyCredit's ProcessSeason endpoints.
@@ -446,7 +446,7 @@ Changes:
 
 4. Refactor detectCreditsForSeason() to make a single API call instead of looping ProcessEpisode per episode.
 
-5. The season object from season_list has both SeasonId and SeasonNumber — use SeasonNumber as the new endpoints require it.
+5. The season object from season_list has both SeasonId and SeasonNumber - use SeasonNumber as the new endpoints require it.
 
 6. If ProcessSeason needs a JSON body (not query params), add a creditsDetectorPostJson() helper in segment_reporting_helpers.js.
 
@@ -457,7 +457,7 @@ When done, mark Session 5B as [x] in docs/plans/issue-execution-guide.md and inc
 
 ---
 
-### Session 5C — Extend Season Actions with Bulk Operations (#78)
+### Session 5C - Extend Season Actions with Bulk Operations (#78)
 
 ```
 Implement issue #78: Extend the season-level Actions dropdown to include bulk operations beyond credits detection.
@@ -465,11 +465,11 @@ Implement issue #78: Extend the season-level Actions dropdown to include bulk op
 File: segment_reporting/Pages/segment_series.js
 
 Changes:
-1. Make the season Actions dropdown unconditional — it currently only renders when EmbyCredits is installed. The new menu items (Delete, Set Credits to End) don't depend on EmbyCredits. Detect items should still be conditionally included.
+1. Make the season Actions dropdown unconditional - it currently only renders when EmbyCredits is installed. The new menu items (Delete, Set Credits to End) don't depend on EmbyCredits. Detect items should still be conditionally included.
 
 2. Add menu items to showSeasonActionsMenu():
-   - Delete submenu (Intros / Credits / Both) — uses helpers.createSubmenuItem() pattern from per-episode Actions
-   - Set Credits to End — uses existing helpers.bulkSetCreditsEnd()
+   - Delete submenu (Intros / Credits / Both) - uses helpers.createSubmenuItem() pattern from per-episode Actions
+   - Set Credits to End - uses existing helpers.bulkSetCreditsEnd()
    - Divider, then Detect All / Detect Missing (existing, conditional on creditsDetectorAvailable)
 
 3. The Delete and Set Credits to End operations need item IDs. If episodes are already cached (loadedSeasons[seasonId]), use them directly. If not loaded yet, load them first via the episode_list endpoint, then proceed.
@@ -483,7 +483,7 @@ When done, mark Session 5C as [x] in docs/plans/issue-execution-guide.md and inc
 
 ---
 
-### Session 6A — User Guide Screenshots (#62)
+### Session 6A - User Guide Screenshots (#62)
 
 ```
 Implement issue #62: Add feature-highlight screenshots to the User Guide.

--- a/segment_reporting/Api/SegmentReportingAPI.cs
+++ b/segment_reporting/Api/SegmentReportingAPI.cs
@@ -500,14 +500,14 @@ namespace segment_reporting.Api
 
             if (!string.IsNullOrEmpty(request.SeasonId))
             {
-                // JS encodeURIComponent(null) sends literal "null" — treat as NULL SeasonId
+                // JS encodeURIComponent(null) sends literal "null" - treat as NULL SeasonId
                 string seasonId = IsJsNullString(request.SeasonId) ? null : request.SeasonId;
                 string seriesScope = IsJsNullString(request.SeriesId) ? null : request.SeriesId;
 
                 // Null-season queries MUST be scoped to a series to avoid cross-series results
                 if (seasonId == null && string.IsNullOrEmpty(seriesScope))
                 {
-                    _logger.Warn("GetEpisodeList: null seasonId without seriesId — returning empty");
+                    _logger.Warn("GetEpisodeList: null seasonId without seriesId - returning empty");
                     return new List<SegmentInfo>();
                 }
 

--- a/segment_reporting/Pages/segment_custom_query.html
+++ b/segment_reporting/Pages/segment_custom_query.html
@@ -89,7 +89,7 @@
             display: inline-block;
             position: relative;
         }
-        /* Shared autocomplete dropdown — background set dynamically by JS */
+        /* Shared autocomplete dropdown - background set dynamically by JS */
         #segmentCustomQueryPage .sr-ac-dropdown {
             position: absolute;
             left: 0;

--- a/segment_reporting/Pages/segment_custom_query.js
+++ b/segment_reporting/Pages/segment_custom_query.js
@@ -41,7 +41,7 @@ define([Dashboard.getConfigurationResourceUrl('segment_reporting_helpers.js')], 
                 }
             }
             var canEdit = hasItemId && editableColumns.length > 0;
-            var canDelete = hasItemId; // Delete only needs ItemId — marker type chosen from menu
+            var canDelete = hasItemId; // Delete only needs ItemId - marker type chosen from menu
             var canPlayback = hasItemId && editableColumns.length > 0;
             return {
                 canEdit: canEdit,
@@ -168,7 +168,7 @@ define([Dashboard.getConfigurationResourceUrl('segment_reporting_helpers.js')], 
                 })
                 .catch(function (err) {
                     console.error('distinct_values fetch failed for ' + fieldName + ':', err);
-                    // Don't cache failures — allow retry on next focus
+                    // Don't cache failures - allow retry on next focus
                     callback([]);
                 });
         }
@@ -543,7 +543,7 @@ define([Dashboard.getConfigurationResourceUrl('segment_reporting_helpers.js')], 
             // Parse SELECT columns
             if (match('keyword', 'SELECT')) {
                 if (peek() && peek().type === 'star') {
-                    next(); // consume * — selectedColumns stays empty = all
+                    next(); // consume * - selectedColumns stays empty = all
                 } else {
                     while (pos < tokens.length) {
                         var ct = peek();
@@ -1023,7 +1023,7 @@ define([Dashboard.getConfigurationResourceUrl('segment_reporting_helpers.js')], 
         function onBuilderChange(e) {
             var target = e.target;
 
-            // Skip autocomplete inputs — handled by onAcInput
+            // Skip autocomplete inputs - handled by onAcInput
             if (target.classList && (target.classList.contains('sr-pill-input') || target.classList.contains('sr-ac-input'))) return;
 
             var action = target.getAttribute('data-action');
@@ -1345,7 +1345,7 @@ define([Dashboard.getConfigurationResourceUrl('segment_reporting_helpers.js')], 
             _dragStartX = e.clientX;
             _dragStartY = e.clientY;
             _draggedPill = el;
-            _draggedCol = null; // not committed yet — wait for threshold
+            _draggedCol = null; // not committed yet - wait for threshold
             _wasDragging = false;
 
             document.addEventListener('pointermove', onPillPointerMove);
@@ -1393,7 +1393,7 @@ define([Dashboard.getConfigurationResourceUrl('segment_reporting_helpers.js')], 
             document.removeEventListener('pointerup', onPillPointerUp);
 
             if (!_draggedCol) {
-                // Threshold was never crossed — let the click handler toggle the pill
+                // Threshold was never crossed - let the click handler toggle the pill
                 _draggedPill = null;
                 return;
             }

--- a/segment_reporting/Pages/segment_series.js
+++ b/segment_reporting/Pages/segment_series.js
@@ -740,10 +740,10 @@ define([Dashboard.getConfigurationResourceUrl('segment_reporting_helpers.js')], 
             var modeLabel = copyMode === 'intros' ? 'intros' : copyMode === 'credits' ? 'credits' : 'intros + credits';
             var banner = view.querySelector('#bulkSourceBanner');
             var bannerText = view.querySelector('#bulkSourceText');
-            bannerText.textContent = 'Copying ' + modeLabel + ' from Episode ' + (ep.EpisodeNumber || '?') + ' — ' + (ep.ItemName || 'Unknown');
+            bannerText.textContent = 'Copying ' + modeLabel + ' from Episode ' + (ep.EpisodeNumber || '?') + ' - ' + (ep.ItemName || 'Unknown');
             banner.style.display = 'block';
 
-            // Re-highlight rows — refresh all visible tables
+            // Re-highlight rows - refresh all visible tables
             var allRows = view.querySelectorAll('tr[data-item-id]');
             allRows.forEach(function (row) {
                 var itemId = row.getAttribute('data-item-id');

--- a/segment_reporting/Plugin.cs
+++ b/segment_reporting/Plugin.cs
@@ -42,7 +42,7 @@ namespace segment_reporting
 
             var pages = new List<PluginPageInfo>
             {
-                // HTML pages — stable, unversioned names (entry points for navigation)
+                // HTML pages - stable, unversioned names (entry points for navigation)
                 new PluginPageInfo
                 {
                     Name = "segment_dashboard",
@@ -59,7 +59,7 @@ namespace segment_reporting
                 new PluginPageInfo { Name = "segment_about", EmbeddedResourcePath = ns + ".Pages.segment_about.html" }
             };
 
-            // JS resources — register both unversioned (dev/fallback) and versioned (cache-busted release builds).
+            // JS resources - register both unversioned (dev/fallback) and versioned (cache-busted release builds).
             // The build script patches HTML data-controller attrs and JS getConfigurationResourceUrl() calls
             // to reference versioned names. The unversioned name remains for dev builds and cached-HTML compat.
             var jsFiles = new[]
@@ -78,7 +78,7 @@ namespace segment_reporting
             {
                 var resourcePath = ns + ".Pages." + js;
 
-                // Unversioned name (always registered — used by dev builds and as fallback for cached HTML)
+                // Unversioned name (always registered - used by dev builds and as fallback for cached HTML)
                 pages.Add(new PluginPageInfo { Name = js, EmbeddedResourcePath = resourcePath });
 
                 // Versioned name (used by release builds where HTML/JS are patched with the cache tag)


### PR DESCRIPTION
Removes em-dashes (replaced with regular dashes) per the project's no-em-dash convention.

## Scope
This PR covers the 7 remaining files in the em-dash sweep:
- README.md
- docs/plans/issue-execution-guide.md
- segment_reporting/Api/SegmentReportingAPI.cs
- segment_reporting/Plugin.cs
- segment_reporting/Pages/segment_custom_query.html
- segment_reporting/Pages/segment_custom_query.js
- segment_reporting/Pages/segment_series.js

## Coordination
The em-dash purge was split conflict-free across three branches so no file is touched twice:
- The About page and USER_GUIDE.md are handled in PR #111.
- CLAUDE.md, DEVELOPER.md, and SegmentRepository.cs are handled in PR #110.
- This PR covers the rest.

Mechanical change only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)