### PR TITLE
test+build: Threading.Analyzers + UAT concurrency stress check (#106 Phase 1/3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ NPM_PREFIX := segment_reporting
 
 .PHONY: help restore build build-release test format format-check lint gate \
         hooks hooks-install docs docs-deps docs-serve screenshots clean \
-        uat-deploy uat-seed uat-test bruno uat-clean uat
+        uat-deploy uat-seed uat-test bruno uat-clean uat uat-concurrency
 
 help: ## Show this help
 	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
@@ -79,6 +79,9 @@ uat-test: ## UAT: run the Bruno API assertions against UAT (reads apiKey from .e
 		--env-var "apiKey=$$(grep -E '^EMBY_UAT_API_KEY=' ../../.env | head -1 | cut -d= -f2- | tr -d '\r\"')"
 
 bruno: uat-test ## UAT: alias for uat-test
+
+uat-concurrency: ## UAT: stress SegmentRepository lock ordering (#66) with concurrent API requests
+	bash scripts/uat/concurrency.sh
 
 uat-clean: ## UAT: remove synthetic libraries/media, reset Local.bru IDs
 	bash scripts/uat/clean.sh

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -88,10 +88,10 @@ can always run the underlying command shown below by hand.
 | `make clean` | `dotnet clean` + remove `bin`/`obj`/`site` | Remove build output and the generated docs site. |
 
 The UAT Emby harness ships as `make uat-deploy` / `uat-seed` / `uat-test`
-(alias `bruno`) / `uat-clean` / `uat`, driving `scripts/uat/*`. Fuzzing and
-leak detection (`make fuzz` / `leak-check`) remain Phase 3 and ship with that
-work. See [UAT Emby Harness](#uat-emby-harness) below before running any of
-the `uat-*` targets.
+(alias `bruno`) / `uat-concurrency` / `uat-clean` / `uat`, driving
+`scripts/uat/*`. Fuzzing and leak detection (`make fuzz` / `leak-check`) remain
+Phase 3 and ship with that work. See [UAT Emby Harness](#uat-emby-harness) below
+before running any of the `uat-*` targets.
 
 ### Building the Plugin
 
@@ -167,6 +167,7 @@ seed media -> Emby ingest -> plugin sync -> set markers -> read reports -> asser
 | `make uat-deploy` | Build the Release DLL, `docker cp` it into the container's `/config/plugins`, restart Emby, wait until healthy. |
 | `make uat-seed` | Generate sparse media + lockdata NFOs, `docker cp` into `/uat-media`, create the `SR-UAT-TV` / `SR-UAT-Movies` libraries via the VirtualFolders API, scan, `sync_now`, write a varied marker coverage matrix, and capture the discovered IDs into `bruno-tests/.../environments/Local.bru`. Idempotent. |
 | `make uat-test` (alias `make bruno`) | Run the Bruno collection assertions against UAT (reads `apiKey` from `.env`). |
+| `make uat-concurrency` | Stress `SegmentRepository` lock ordering (#66) with concurrent API workers (mixed reads plus an idempotent `/uat-media` write); fails on any request error/timeout or rowCount drift. Needs `make uat-seed` first. Tunable via `WORKERS` / `ITERATIONS` (defaults 8 / 25). Not run in CI. |
 | `make uat-clean` | Delete the `SR-UAT` libraries, remove `/uat-media` in the container, and reset the captured IDs in `Local.bru` to placeholders. |
 | `make uat` | Convenience chain: `uat-deploy` -> `uat-seed` -> `uat-test`. |
 
@@ -2290,8 +2291,26 @@ The project targets `net8.0` to match the CI SDK; `<RollForward>Major</RollForwa
 lets the test host run on a newer locally-installed runtime when 8.0 is absent.
 CI runs them as a dedicated step in the build job (see the CI/CD Pipeline section).
 
-Future work (issue #106) adds repository/migration tests, SharpFuzz fuzz targets
-for the query parser, the Threading.Analyzers, and a Dockerized UAT Emby harness.
+The plugin analyzer set also includes `Microsoft.VisualStudio.Threading.Analyzers`
+(threading-antipattern static checks), enforced by the `-warnaserror` Release
+build in CI and the local pre-push gate.
+
+Remaining issue #106 work: SharpFuzz fuzz targets for the query validators (run
+in Docker, local-only).
+
+### Concurrency Stress (UAT, manual)
+
+The plugin's SQLite stack (`SQLitePCL.pretty` plus the raw provider Emby bundles)
+cannot be hosted outside the Emby runtime, so `SegmentRepository`'s lock ordering
+(#66) is exercised against a running UAT server rather than in a standalone unit
+test. `make uat-concurrency` (or `bash scripts/uat/concurrency.sh`) fires many
+concurrent API workers that mix reads (library summary, cache stats, sync status,
+custom query, series list, season list) with an idempotent write (`update_segment` on a seeded
+`/uat-media` episode). It fails if any request errors or times out (a possible
+deadlock) or if the row count drifts (the writes are idempotent, so drift implies
+a lost update or corruption). Local manual gate only: it needs the UAT Emby up and
+seeded (`make uat-seed`) and never runs in CI or a git hook. Tune with the
+`WORKERS` and `ITERATIONS` environment variables (defaults 8 and 25).
 
 ### Manual Testing Workflow
 

--- a/scripts/uat/concurrency.sh
+++ b/scripts/uat/concurrency.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# concurrency.sh -- exercise SegmentRepository's lock ordering (#66) under load
+# by firing many concurrent API requests at the running UAT Emby. This is the
+# Phase 3 concurrency guard: the plugin's SQLite stack (SQLitePCL.pretty + the
+# raw provider Emby bundles) cannot be hosted outside the Emby runtime, so the
+# only faithful way to stress the read/write locks is against a real server.
+#
+# Local manual gate only (needs the UAT Emby up + seeded): never run by CI or a
+# git hook. Reads are always exercised; an idempotent write is added when a
+# seeded episode can be discovered, so reads and writes contend for the locks.
+#
+#   WORKERS     concurrent workers (default 8)
+#   ITERATIONS  request rounds per worker (default 25)
+#
+# A deadlock or lock-ordering regression surfaces as request timeouts / 500s
+# (curl -fsS fails -> recorded) or as a drifting row count, and fails the run.
+
+set -euo pipefail
+
+SR_UAT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/uat/lib.sh disable=SC1091
+. "$SR_UAT_DIR/lib.sh"
+
+WORKERS="${WORKERS:-8}"
+ITERATIONS="${ITERATIONS:-25}"
+
+# A fixed, deterministic IntroStart value (5s in ticks). Writing the same value
+# every time keeps the write idempotent so the run does not corrupt seeded data.
+FIXED_INTRO_TICKS=50000000
+
+# URL-encode the read-path query once (spaces and parens would otherwise make a
+# malformed URL). @uri matches how the Bruno collection encodes the same call.
+CUSTOM_QUERY="$(jq -rn --arg s 'SELECT COUNT(*) FROM MediaSegments' '$s|@uri')"
+
+wait_for_healthy
+
+# --- discover IDs (best-effort; reads below degrade gracefully without them) --
+log "Discovering sample IDs from the API"
+library_id="$(sr_get /emby/segment_reporting/library_summary \
+    | jq -r '.[0].LibraryId // empty' 2>/dev/null || true)"
+series_id=""
+if [ -n "$library_id" ]; then
+    series_id="$(sr_get /emby/segment_reporting/series_list "libraryId=${library_id}" \
+        | jq -r '(.series // [])[0].SeriesId // empty' 2>/dev/null || true)"
+fi
+# A seeded episode ItemId for the idempotent write half of the stress. Do not
+# pass Limit=1: it would truncate the API result before the /uat-media filter
+# runs, so a first episode outside the seeded library would silently drop the
+# write path. Filter the full episode list, then take the first match.
+episode_id="$(sr_get /emby/Items 'Recursive=true&IncludeItemTypes=Episode&Fields=Path' \
+    | jq -r '(.Items // []) | map(select((.Path // "")|startswith("/uat-media"))) | .[0].Id // empty' 2>/dev/null || true)"
+
+log "library_id=${library_id:-<none>} series_id=${series_id:-<none>} episode_id=${episode_id:-<none>}"
+if [ -z "$episode_id" ]; then
+    log "No seeded episode found -- running READ-ONLY (run 'make uat-seed' for read+write contention)."
+fi
+
+rows_before="$(sr_get /emby/segment_reporting/cache_stats | jq -r '.rowCount // 0')"
+log "rowCount before: $rows_before"
+
+FAIL_DIR="$RUN_LOG_DIR/fail"
+mkdir -p "$FAIL_DIR"
+
+# --- one worker: a bounded round of mixed reads (+ idempotent write) ----------
+worker() {
+    local id="$1" i rc tmp
+    # keep_first preserves the first non-zero exit of the iteration, so a later
+    # successful request can never mask an earlier failure.
+    keep_first() { tmp=$?; [ "$rc" -eq 0 ] && rc=$tmp; }
+    for ((i = 0; i < ITERATIONS; i++)); do
+        rc=0
+        {
+            sr_get /emby/segment_reporting/library_summary >/dev/null &&
+            sr_get /emby/segment_reporting/cache_stats >/dev/null &&
+            sr_get /emby/segment_reporting/sync_status >/dev/null &&
+            sr_post /emby/segment_reporting/submit_custom_query \
+                "query=${CUSTOM_QUERY}" >/dev/null
+        } || keep_first
+
+        if [ -n "$library_id" ]; then
+            sr_get /emby/segment_reporting/series_list "libraryId=${library_id}" >/dev/null || keep_first
+        fi
+        if [ -n "$series_id" ]; then
+            sr_get /emby/segment_reporting/season_list "seriesId=${series_id}" >/dev/null || keep_first
+        fi
+        if [ -n "$episode_id" ]; then
+            # Idempotent write: always the same marker value, so it stresses the
+            # write path / lock ordering without changing the row count.
+            sr_post /emby/segment_reporting/update_segment \
+                "ItemId=${episode_id}&MarkerType=IntroStart&Ticks=${FIXED_INTRO_TICKS}" >/dev/null || keep_first
+        fi
+
+        if [ "$rc" -ne 0 ]; then
+            printf 'worker %s iter %s: request failed (rc=%s)\n' "$id" "$i" "$rc" \
+                >> "$FAIL_DIR/worker-$id"
+        fi
+    done
+}
+
+log "Launching $WORKERS workers x $ITERATIONS iterations"
+pids=()
+for ((w = 0; w < WORKERS; w++)); do
+    worker "$w" &
+    pids+=("$!")
+done
+
+# Bounded join: if a worker hangs (deadlock), it cannot stall the run forever --
+# curl's --max-time bounds each request, so workers always terminate.
+rc_any=0
+for pid in "${pids[@]}"; do
+    wait "$pid" || rc_any=1
+done
+
+rows_after="$(sr_get /emby/segment_reporting/cache_stats | jq -r '.rowCount // 0')"
+log "rowCount after: $rows_after"
+
+# --- verdict ------------------------------------------------------------------
+fail_count=0
+if [ -d "$FAIL_DIR" ]; then
+    fail_count="$(find "$FAIL_DIR" -type f | wc -l | tr -d ' ')"
+fi
+
+status=0
+if [ "$fail_count" -ne 0 ]; then
+    echo "FAIL: $fail_count worker(s) recorded request failures:" >&2
+    cat "$FAIL_DIR"/* >&2 || true
+    status=1
+fi
+if [ "$rc_any" -ne 0 ]; then
+    echo "FAIL: at least one worker exited non-zero." >&2
+    status=1
+fi
+if [ "$rows_before" != "$rows_after" ]; then
+    echo "FAIL: rowCount drifted ($rows_before -> $rows_after); writes were idempotent, so this indicates corruption or a lost update." >&2
+    status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+    log "PASS: $WORKERS x $ITERATIONS concurrent rounds, no errors, rowCount stable at $rows_after."
+fi
+exit "$status"

--- a/segment_reporting/segment_reporting.csproj
+++ b/segment_reporting/segment_reporting.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0" PrivateAssets="all" />
     <PackageReference Include="IDisposableAnalyzers" Version="4.0.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Part of #106 (testing infrastructure). This is PR1 of 2; PR2 (SharpFuzz fuzz targets + memory-profiling docs) follows and will close #106.

## What this adds

- **Microsoft.VisualStudio.Threading.Analyzers** in the plugin analyzer set (threading-antipattern static checks), enforced by the existing `-warnaserror` Release build in CI and the local pre-push gate. Zero findings surfaced (the plugin is synchronous against Emby's API).
- **UAT concurrency stress check** (`scripts/uat/concurrency.sh`, `make uat-concurrency`): a local/manual gate that stresses `SegmentRepository`'s lock ordering (#66) with many concurrent API workers mixing reads (library summary, cache stats, sync status, custom query, series list) with an idempotent write (`update_segment` on a seeded `/uat-media` episode). Fails on any request error/timeout (possible deadlock) or row-count drift (idempotent writes, so drift implies a lost update or corruption).
- **DEVELOPER.md** updated (analyzer note + Concurrency Stress section).

## Why a UAT-based concurrency check instead of a standalone unit test

The plan originally called for an in-process xUnit stress test, but the plugin's SQLite stack (`SQLitePCL.pretty.core` 1.2.2) is bound to the `SQLitePCLRaw` build Emby bundles at runtime. No public `SQLitePCLRaw` release satisfies pretty 1.2.2 (the string `create_collation` of raw 1.x and the `ReadOnlySpan` bind overloads of raw 2.0.4+ never coexist in one release), so a real `SegmentRepository` cannot be constructed outside the Emby host. Exercising the locks against the running UAT server is both feasible and more faithful, and it reuses the Phase 2 harness.

## Validation

- `pre-push-gate.sh` green (Release `-warnaserror` build + format + lint)
- `shellcheck` + `bash -n` clean on the new script
- Live run against UAT Emby: 8 workers x 25 iterations, no errors, rowCount stable

## Gate placement

| Piece | CI | Local hook | Manual |
|-------|----|-----------|--------|
| Threading.Analyzers | yes (build) | yes (pre-push build) | - |
| Concurrency check | no | no | `make uat-concurrency` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)