### PR TITLE
chore: remove emoji from release.yml category titles

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,30 +6,30 @@ changelog:
     authors:
       - dependabot
   categories:
-    - title: 🚀 Features
+    - title: Features
       labels:
         - feature
         - enhancement
         - new
-    - title: 🐛 Bug Fixes
+    - title: Bug Fixes
       labels:
         - bug
         - fix
         - bugfix
-    - title: 📚 Documentation
+    - title: Documentation
       labels:
         - documentation
         - docs
-    - title: 🏗️ Infrastructure
+    - title: Infrastructure
       labels:
         - ci
         - build
         - infra
-    - title: 🔧 Maintenance
+    - title: Maintenance
       labels:
         - refactor
         - chore
         - maintenance
-    - title: 📦 Other Changes
+    - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
## Summary

GitHub's auto-generated "What's Changed" release notes pull their section
headings from the category `title` fields in `.github/release.yml`. Those
titles each carried an emoji, so the emoji leaked into the published v1.4.0.0
release body. This strips the emoji from all six titles
(Features / Bug Fixes / Documentation / Infrastructure / Maintenance /
Other Changes) so future auto-generated release notes stay emoji-free, per the
no-emoji-anywhere house rule.

The v1.4.0.0 release body itself was already cleaned by hand; this fixes the
source so it does not recur.

## Scope

Config-only, mechanical. No code or behavior change. Labels unchanged, so PR
categorization is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)