### PR TITLE
a11y linting + keyboard shortcuts; pin fuzz Dockerfile (#132, #133)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Lint JavaScript
         run: npm run lint:js --prefix segment_reporting
 
+      - name: Lint HTML accessibility (html-validate)
+        run: npm run lint:html --prefix segment_reporting
+
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -1755,8 +1755,8 @@ call that backs both per-row and bulk apply/undo.
 
 | Function | Description |
 |----------|-------------|
-| `createOffsetModal(config)` | Builds and returns the offset adjustment modal DOM element. `config` describes which marker rows to show (intro, introEnd, credits) and their current tick values. The modal renders left/right arrow buttons for each row; arrows that would produce a negative tick are disabled. |
-| `showOffsetSnackbar(message, onUndo)` | Displays a transient snackbar with the given message and an **Undo** button; auto-dismisses after 12 seconds (12000 ms). Calls `onUndo()` if the user clicks Undo before it dismisses. |
+| `createOffsetModal(config)` | Builds and returns the offset adjustment modal DOM element. `config` describes which marker rows to show (intro, introEnd, credits) and their current tick values. The modal renders left/right arrow buttons for each row; arrows that would produce a negative tick are disabled. It is a real ARIA modal (`role="dialog"`, `aria-modal="true"`, `aria-labelledby` the heading) with a focus trap, initial focus into the dialog, and focus return to the trigger on close. Each adjustable value is a `role="spinbutton"` (with `aria-valuenow` / `aria-valuetext` / `aria-valuemin`) that accepts arrow-key nudging (see Keyboard Shortcuts below). Enter applies, Escape cancels. |
+| `showOffsetSnackbar(message, onUndo)` | Displays a transient snackbar (`role="status"`) with the given message and a keyboard-focusable **Undo** button; auto-dismisses after 12 seconds (12000 ms). Calls `onUndo()` if the user clicks (or activates via keyboard) Undo before it dismisses. |
 | `buildBulkSetBody(items)` | Accepts an array of objects (each with `itemId`, `introStartTicks`, `introEndTicks`, `creditsStartTicks`; null means untouched) and constructs the comma-separated query-string parameters expected by `POST /segment_reporting/bulk_set_segments`. |
 | `applyBulkSet(items)` | Calls `buildBulkSetBody`, posts to `bulk_set_segments`, and returns a Promise resolving to the `{ succeeded, failed, errors }` response. Used by both the single-item modal Apply path and the multi-item bulk Apply path. |
 
@@ -1804,6 +1804,43 @@ accessible alternative.
   `aria-expanded`, `aria-controls`, `aria-activedescendant`); the dropdown is
   `role="listbox"` with `role="option"` items. Chips expose a keyboard-operable
   remove button (`role="button"`, `aria-label="Remove ..."`).
+
+#### Keyboard Shortcuts (issue #133)
+
+Keyboard support is scoped to the focused control - there are no document- or
+window-level handlers, so nothing conflicts with the Emby dashboard shell, and
+`preventDefault()` is called only when a handler actually consumes the key.
+
+**Offset adjustment dialog (`createOffsetModal`).** Each marker value is an ARIA
+spinbutton in the dialog's tab order:
+
+| Key | Action |
+|-----|--------|
+| Tab / Shift+Tab | Move focus between marker spinbuttons and the dialog buttons (focus is trapped inside the dialog) |
+| ArrowUp / ArrowRight | Nudge the focused marker later by the fine step (250 ms) |
+| ArrowDown / ArrowLeft | Nudge the focused marker earlier by the fine step (250 ms) |
+| Shift+Arrow | Coarse nudge (1 s) |
+| PageUp / PageDown | Page nudge (5 s, later / earlier) |
+| Enter | Apply (unless focus is on a button, which activates normally) |
+| Escape | Cancel |
+
+Step sizes are hardcoded constants in `segment_reporting_helpers.js`
+(`SEGMENT_REPORTING_OFFSET_STEP_TICKS` = 250 ms,
+`SEGMENT_REPORTING_OFFSET_COARSE_STEP_TICKS` = 1 s,
+`SEGMENT_REPORTING_OFFSET_PAGE_STEP_TICKS` = 5 s), not user settings. All marker
+nudging routes through this dialog (a single Apply/Undo commit path); in-table
+nudging is intentionally not provided. Arrow keys are never captured on text
+inputs, `<select>`, or the Custom Query combobox/listbox.
+
+**Inline editor (`createInlineEditor`).** While editing a row's time fields,
+Enter saves the row and Escape cancels. Arrow keys are deliberately left to the
+native text caret (they are not captured), so editing within a field behaves
+normally.
+
+**Deferred.** Milestone M4 (in-table roving tabindex on marker rows) and M5
+(page-level / global shortcuts) are out of scope for this change and tracked as a
+follow-up; the implemented surface is M1 (spinbutton nudging), M2 (inline-editor
+Enter/Escape), and M3 (modal dialog + focusable snackbar Undo).
 
 ---
 
@@ -2486,6 +2523,65 @@ build in CI and the local pre-push gate.
 
 The same validators are also fuzzed with SharpFuzz (Docker, local-only); see
 [Fuzzing the SQL Validators](#fuzzing-the-sql-validators-docker-manual) below.
+
+### Accessibility (a11y) Testing
+
+The plugin targets WCAG 2.1 AA. Accessibility is checked in two tiers, a static
+tier in the gate and a runtime tier run locally against a real Emby.
+
+**Static tier - html-validate (CI + pre-commit gate).** `html-validate` lints the
+embedded plugin pages (`segment_reporting/Pages/*.html`) for the structural
+ARIA/WCAG issues that are visible in the markup: missing form labels, misused or
+invalid ARIA, duplicate ids, missing `<img>` alt text, missing table-header
+`scope`, and broken `aria-*` references. The ruleset lives in
+`segment_reporting/.htmlvalidate.json` (extends `html-validate:recommended` plus
+the relevant `wcag/*` rules). Run it with:
+
+```bash
+npm run lint:html --prefix segment_reporting    # or: cd segment_reporting && npm run lint:html
+```
+
+It is wired into both the lefthook **pre-commit** stage (the `html-validate`
+command, on staged `Pages/*.html`) and the CI **build** job (the "Lint HTML
+accessibility" step), and is also run by `scripts/pre-push-gate.sh` so a local
+`make gate` matches CI. Two `html-validate:recommended` rules are deliberately
+turned off in the config because they are false positives for this codebase, not
+real defects: `prefer-native-element` (the pages use `role="main"` on a `<div>`
+because the Emby SPA shell already provides the `<main>` landmark, and sortable
+`<th>` headers use `role="button"` rather than a nested native `<button>`) and
+`element-permitted-content` (Emby plugin pages legitimately inline a `<style>`
+block inside the page `<div>` fragment).
+
+**Runtime tier - axe-core (local / UAT only).** Color contrast and other checks
+that can only be evaluated against rendered, themed, data-loaded pages are not
+statically detectable, so they are covered by `scripts/axe-a11y.mjs`. It reuses
+the same SPA login and hash-route navigation as `scripts/capture-screenshots.mjs`,
+drives each top-level plugin page in headless Chromium, runs `@axe-core/playwright`
+with the WCAG 2.1 AA tag set, and (optionally, with `AXE_TREE=1`) dumps the
+accessibility tree. Because it needs a running Emby server and an authenticated
+user session, it is **local/UAT-only and intentionally NOT part of the blocking
+CI gate** (same boundary as the screenshot tooling). Run it with:
+
+```bash
+npm run a11y:axe --prefix segment_reporting
+# or, against the UAT Emby:
+CAPTURE_TARGET=uat node scripts/axe-a11y.mjs
+# subset of pages, plus accessibility-tree dump:
+AXE_ONLY=settings,about AXE_TREE=1 node scripts/axe-a11y.mjs
+```
+
+It exits non-zero if any audited page reports a violation, printing the rule,
+impact, target selector, and failure summary for each.
+
+> **Color-contrast note (issue #132).** axe flagged serious color-contrast
+> violations on the Dashboard, Custom Query, Settings, and About pages. The
+> low-opacity descriptive text on Custom Query, Settings, and About was raised to
+> a higher opacity (a strictly contrast-improving, theme-independent change) in
+> the page markup. The remaining cases use `color: inherit` (the live Emby theme
+> supplies the foreground/background pair), so the exact contrast ratio can only
+> be confirmed at runtime with `npm run a11y:axe` against a themed Emby; re-run it
+> after any change to a page's muted-text styling to confirm AA is met in the
+> active theme.
 
 ### Concurrency Stress (UAT, manual)
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -412,7 +412,7 @@ inside the dialog until you close it.
 
 When the dialog closes, focus returns to the control you opened it from.
 
-### Inline Editing
+### Inline Editor Keyboard Controls
 
 While editing a row's time fields in the inline editor:
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -370,11 +370,13 @@ markers earlier or later in 250 ms steps without opening the full inline editor.
      this to trim or extend the intro's end point.
    - **Credits** - moves CreditsStart earlier or later.
 4. For each row, click the left arrow to move that marker **earlier** or the
-   right arrow to move it **later** (each click = 250 ms).
+   right arrow to move it **later** (each click = 250 ms). You can also adjust a
+   row from the keyboard - see [Keyboard Shortcuts](#keyboard-shortcuts) below.
 5. Click **Apply** to save the change.
 
 A brief **Undo** prompt appears after applying. Click it immediately to restore
-the previous values if the adjustment was wrong.
+the previous values if the adjustment was wrong. The Undo control is keyboard
+focusable, so you can reach it with Tab and activate it with Enter or Space.
 
 **Notes:**
 
@@ -384,6 +386,48 @@ the previous values if the adjustment was wrong.
   prevent negative timestamps.
 - This is available on the Series Detail page (episode rows), the Library page
   (movie rows), and the Custom Query results table.
+
+---
+
+## Keyboard Shortcuts
+
+Several controls can be operated entirely from the keyboard, which is useful for
+fast adjustments and required for screen-reader and keyboard-only access.
+
+### Timing Adjustment Dialog
+
+When the **Adjust timing** dialog is open (per-row or bulk), each marker value is
+a focusable control. Tab moves between them and the dialog buttons; focus stays
+inside the dialog until you close it.
+
+| Key | Action |
+|-----|--------|
+| Tab / Shift+Tab | Move between the marker rows and the Cancel / Apply buttons |
+| Up arrow or Right arrow | Move the focused marker **later** by 250 ms |
+| Down arrow or Left arrow | Move the focused marker **earlier** by 250 ms |
+| Shift + arrow | Larger 1-second step in the same direction |
+| Page Up / Page Down | 5-second step (later / earlier) |
+| Enter | Apply the changes |
+| Escape | Cancel and close the dialog without saving |
+
+When the dialog closes, focus returns to the control you opened it from.
+
+### Inline Editing
+
+While editing a row's time fields in the inline editor:
+
+| Key | Action |
+|-----|--------|
+| Enter | Save the row |
+| Escape | Cancel editing and discard the changes |
+| Left / Right arrow | Move the text cursor within the time field (normal typing behavior) |
+
+### Tables and Lists
+
+- **Sortable column headers** (Series and Movie tables): press Tab to focus a
+  header, then Enter or Space to sort by that column.
+- **Snackbar Undo**: after applying a timing change, press Tab to reach the
+  **Undo** control in the prompt, then Enter or Space to undo.
 
 ---
 
@@ -475,7 +519,8 @@ You can apply the same timing shift to all selected items at once using the
 2. Click **Adjust timing** in the bulk action bar.
 3. Choose the shift direction and amount (250 ms per step) for each marker
    type in the modal - the same three rows as the per-row modal (Intro, Intro
-   end, Credits).
+   end, Credits). The dialog supports the same keyboard shortcuts as the per-row
+   version (see [Keyboard Shortcuts](#keyboard-shortcuts)).
 4. Review the confirmation prompt showing how many items will be updated (up
    to 500 items per operation).
 5. Click **Apply** to commit the shift to all selected items.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -16,6 +16,13 @@ pre-commit:
       glob: "segment_reporting/Pages/*.js"
       exclude: "*.min.js"
       run: npx --prefix segment_reporting eslint --config segment_reporting/eslint.config.mjs {staged_files}
+    html-validate:
+      # Static a11y/WCAG lint on the embedded plugin pages. Catches missing form
+      # labels, bad ARIA, duplicate ids, missing img alt, table-header scope, etc.
+      # Runtime-only checks (color contrast) are covered by scripts/axe-a11y.mjs,
+      # a local UAT-only tool that is not wired into this gate.
+      glob: "segment_reporting/Pages/*.html"
+      run: npx --prefix segment_reporting html-validate --config segment_reporting/.htmlvalidate.json {staged_files}
     whitespace:
       run: git diff --cached --check
     gitleaks:

--- a/scripts/axe-a11y.mjs
+++ b/scripts/axe-a11y.mjs
@@ -161,6 +161,14 @@ async function main() {
     const wantTree = process.env.AXE_TREE === '1';
     const targets = PAGES.filter((p) => !only || only.includes(p.key));
 
+    if (only && targets.length === 0) {
+        console.error(
+            `AXE_ONLY="${process.env.AXE_ONLY}" matched no pages. ` +
+            `Available keys: ${PAGES.map((p) => p.key).join(', ')}`
+        );
+        process.exit(1);
+    }
+
     const browser = await chromium.launch({ headless: true });
     const context = await browser.newContext({
         viewport: VIEWPORT,

--- a/scripts/axe-a11y.mjs
+++ b/scripts/axe-a11y.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * Runtime accessibility audit for the Segment Reporting plugin pages.
+ *
+ * This is the RUNTIME tier of the plugin's two-tier a11y check (issue #132):
+ *   - Static tier:  `npm run lint:html` (html-validate) runs in the pre-commit
+ *                   hook and CI. It catches structural ARIA/WCAG issues that are
+ *                   visible in the markup (missing labels, bad roles, dup ids,
+ *                   missing img alt, table-header scope).
+ *   - Runtime tier: THIS script. It drives a real, themed, data-loaded page in a
+ *                   headless browser and runs axe-core, which can evaluate things
+ *                   only computable at runtime, most importantly COLOR CONTRAST
+ *                   (the rendered foreground/background pair after the live Emby
+ *                   theme and any opacity are applied).
+ *
+ * Like capture-screenshots.mjs, this needs a running Emby server with the plugin
+ * installed and an authenticated user session, so it is LOCAL / UAT-ONLY and is
+ * intentionally NOT wired into the blocking CI gate. It reuses the same SPA
+ * login + hash-route navigation approach as capture-screenshots.mjs.
+ *
+ * Prerequisites:
+ *   npm install            (installs @axe-core/playwright)
+ *   npx playwright install chromium
+ *
+ * Usage (from repo root):
+ *   EMBY_UAT_URL=http://localhost:8096 EMBY_UAT_USER=admin EMBY_UAT_PASSWORD=... \
+ *     CAPTURE_TARGET=uat node scripts/axe-a11y.mjs
+ *
+ *   node scripts/axe-a11y.mjs            # prod-style defaults (localhost:8096)
+ *   AXE_ONLY=dashboard,settings node scripts/axe-a11y.mjs   # subset of pages
+ *
+ * Environment variables (same names as capture-screenshots.mjs):
+ *   CAPTURE_TARGET  "uat" to target the UAT Emby (default: prod-style localhost)
+ *   EMBY_URL        Emby server URL (default: http://localhost:8096, or
+ *                   EMBY_UAT_URL in UAT mode)
+ *   EMBY_API_KEY    Admin API key (or EMBY_UAT_API_KEY in UAT mode)
+ *   EMBY_USER       Admin username (or EMBY_UAT_USER in UAT mode). Required.
+ *   EMBY_PASSWORD   Admin password (or EMBY_UAT_PASSWORD in UAT mode)
+ *   AXE_ONLY        Comma-separated page keys to audit (default: all)
+ *   AXE_TREE        "1" to also dump the accessibility tree per page
+ *
+ * Exit status: 0 = no violations on any audited page; 1 = at least one
+ * violation, or a setup/login failure. The full violation report is printed.
+ */
+
+import { chromium } from 'playwright';
+import { AxeBuilder } from '@axe-core/playwright';
+
+const UAT = (process.env.CAPTURE_TARGET || '').toLowerCase() === 'uat';
+
+const EMBY_URL = process.env.EMBY_URL
+    || (UAT ? process.env.EMBY_UAT_URL : undefined)
+    || (!UAT ? 'http://localhost:8096' : undefined);
+const API_KEY = process.env.EMBY_API_KEY || (UAT ? process.env.EMBY_UAT_API_KEY : undefined);
+const EMBY_USER = process.env.EMBY_USER || (UAT ? process.env.EMBY_UAT_USER : undefined);
+const EMBY_PASSWORD = process.env.EMBY_PASSWORD || (UAT ? process.env.EMBY_UAT_PASSWORD : '');
+
+// Fail closed in UAT mode if no URL is set (mirrors capture-screenshots.mjs).
+if (UAT && !EMBY_URL) {
+    console.error('Error: CAPTURE_TARGET=uat requires EMBY_URL or EMBY_UAT_URL to be set explicitly.');
+    process.exit(1);
+}
+
+if (!EMBY_USER) {
+    const userVar = UAT ? 'EMBY_USER or EMBY_UAT_USER' : 'EMBY_USER';
+    console.error(`Error: ${userVar} (and the matching password) are required for SPA login.`);
+    console.error('The plugin pages use Emby ApiClient, which needs an authenticated user session.');
+    process.exit(1);
+}
+
+const VIEWPORT = { width: 1460, height: 1000 };
+
+// WCAG 2.1 AA tag set, matching the plugin's stated conformance target.
+const AXE_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+
+// Each plugin page: its configurationpage name and the DOM id that signals the
+// page has mounted. Drill-down pages (library/series) are reached by clicking
+// through, so only the top-level pages are listed here for the direct audit.
+const PAGES = [
+    { key: 'dashboard', name: 'segment_dashboard', id: 'segmentDashboardPage' },
+    { key: 'custom-query', name: 'segment_custom_query', id: 'segmentCustomQueryPage' },
+    { key: 'settings', name: 'segment_settings', id: 'segmentSettingsPage' },
+    { key: 'about', name: 'segment_about', id: 'segmentAboutPage' }
+];
+
+/** Log in to the Emby SPA so ApiClient has an authenticated session. */
+async function login(page) {
+    const user = EMBY_USER;
+    const pw = EMBY_PASSWORD || '';
+    await page.goto(`${EMBY_URL}/web/index.html`, { waitUntil: 'networkidle' });
+    await page.waitForFunction(() => typeof window.ApiClient !== 'undefined', null, { timeout: 15000 });
+    const result = await page.evaluate(async ({ user, pw }) => {
+        try {
+            await ApiClient.authenticateUserByName(user, pw);
+            return { ok: true, uid: ApiClient.getCurrentUserId() };
+        } catch (e) {
+            return { ok: false, err: String(e) };
+        }
+    }, { user, pw });
+    if (!result.ok) {
+        throw new Error('Emby login failed: ' + result.err);
+    }
+    console.log(`Logged in (userId ${result.uid}).`);
+    await page.waitForTimeout(2000);
+}
+
+/**
+ * Navigate to a plugin page WITHIN the Emby SPA via the hash route, keeping the
+ * authenticated ApiClient session and the live theme (so contrast is evaluated
+ * against the real rendered colors). Mirrors capture-screenshots.mjs.
+ */
+async function navigateTo(page, pageName, pageId) {
+    await page.evaluate((name) => {
+        window.location.hash = '#!/configurationpage?name=' + name;
+    }, pageName);
+    await page.waitForSelector(`#${pageId}`, { state: 'attached', timeout: 20000 });
+    // Allow the viewshow lifecycle + async data loads to finish so the audited
+    // DOM matches what a user sees (tables populated, cards filled in).
+    await page.waitForTimeout(3500);
+}
+
+/** Run axe against the mounted plugin page and return the result object. */
+async function auditPage(page, pg) {
+    const builder = new AxeBuilder({ page })
+        .withTags(AXE_TAGS)
+        .include(`#${pg.id}`);
+    return builder.analyze();
+}
+
+/** Print a compact accessibility-tree dump for the mounted page (optional). */
+async function dumpAccessibilityTree(page, pg) {
+    const snapshot = await page.accessibility.snapshot({ interestingOnly: true });
+    console.log(`\n  Accessibility tree for ${pg.key}:`);
+    console.log(JSON.stringify(snapshot, null, 2));
+}
+
+function formatViolations(pg, violations) {
+    console.log(`\n=== ${pg.key} (${pg.name}) ===`);
+    if (!violations.length) {
+        console.log('  No WCAG 2.1 AA violations.');
+        return;
+    }
+    for (const v of violations) {
+        console.log(`  [${v.impact || 'n/a'}] ${v.id}: ${v.help}`);
+        console.log(`    ${v.helpUrl}`);
+        for (const node of v.nodes) {
+            console.log(`    - ${node.target.join(' ')}`);
+            if (node.failureSummary) {
+                console.log('      ' + node.failureSummary.replace(/\n/g, '\n      '));
+            }
+        }
+    }
+}
+
+async function main() {
+    console.log(`Connecting to Emby at ${EMBY_URL} (${UAT ? 'UAT' : 'prod-style'} mode)`);
+
+    const only = process.env.AXE_ONLY
+        ? process.env.AXE_ONLY.split(',').map((s) => s.trim())
+        : null;
+    const wantTree = process.env.AXE_TREE === '1';
+    const targets = PAGES.filter((p) => !only || only.includes(p.key));
+
+    const browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({
+        viewport: VIEWPORT,
+        extraHTTPHeaders: API_KEY ? { 'X-Emby-Token': API_KEY } : {}
+    });
+    const page = await context.newPage();
+
+    let totalViolations = 0;
+    try {
+        await login(page);
+        for (const pg of targets) {
+            await navigateTo(page, pg.name, pg.id);
+            const result = await auditPage(page, pg);
+            formatViolations(pg, result.violations);
+            totalViolations += result.violations.length;
+            if (wantTree) {
+                await dumpAccessibilityTree(page, pg);
+            }
+        }
+    } catch (err) {
+        console.error('Accessibility audit failed:', err.message);
+        await browser.close();
+        process.exit(1);
+    }
+    await browser.close();
+
+    console.log(`\nAudited ${targets.length} page(s); ${totalViolations} total violation(s).`);
+    process.exit(totalViolations > 0 ? 1 : 0);
+}
+
+main();

--- a/scripts/fuzz/Dockerfile
+++ b/scripts/fuzz/Dockerfile
@@ -1,7 +1,7 @@
 # Linux fuzz environment for SharpFuzz. Built/run on demand by `make fuzz`;
 # never part of CI or a git hook. Keeps the AFL/SharpFuzz toolchain off the
 # developer's (macOS) machine.
-FROM mcr.microsoft.com/dotnet/sdk:8.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0@sha256:fc69dc5e0c9789adaac5c8efce71ead4d016a51318667c4f26ce93574b1b9403
 
 # AFL provides the fuzzing engine SharpFuzz's OutOfProcess runner drives.
 RUN apt-get update \

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -59,4 +59,11 @@ echo "=== JavaScript lint (npm run lint:js) ==="
 npm run lint:js --prefix "$NPM_PREFIX"
 
 echo ""
+echo "=== HTML accessibility lint (npm run lint:html) ==="
+# Static a11y/WCAG check on the embedded pages (missing labels, bad ARIA,
+# duplicate ids, missing img alt, etc). Runtime contrast checks (axe) are a
+# local UAT-only tool and are intentionally not part of this gate.
+npm run lint:html --prefix "$NPM_PREFIX"
+
+echo ""
 echo "All pre-push checks passed (matches CI build job)."

--- a/segment_reporting/.htmlvalidate.json
+++ b/segment_reporting/.htmlvalidate.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://html-validate.org/schemas/config.json",
+  "extends": [
+    "html-validate:recommended"
+  ],
+  "rules": {
+    "wcag/h30": "error",
+    "wcag/h32": "off",
+    "wcag/h36": "error",
+    "wcag/h37": "error",
+    "wcag/h63": "error",
+    "wcag/h67": "error",
+    "wcag/h71": "error",
+    "input-missing-label": "error",
+    "valid-id": "error",
+    "no-dup-id": "error",
+    "aria-label-misuse": "error",
+    "no-redundant-role": "error",
+    "no-redundant-for": "error",
+    "no-implicit-button-type": "off",
+    "prefer-native-element": "off",
+    "element-permitted-content": "off",
+    "element-required-attributes": "error",
+    "no-inline-style": "off",
+    "void-style": "off",
+    "require-sri": "off",
+    "long-title": "off",
+    "no-trailing-whitespace": "off",
+    "doctype-style": "off",
+    "missing-doctype": "off",
+    "no-missing-references": "error"
+  }
+}

--- a/segment_reporting/Pages/segment_about.html
+++ b/segment_reporting/Pages/segment_about.html
@@ -75,31 +75,31 @@
                             <a href="https://sydlexius.github.io/Segment_Reporting/" target="_blank" rel="noopener" style="color: inherit; text-decoration: underline;">
                                 Documentation / User Guide
                             </a>
-                            <span style="opacity: 0.6;"> - Setup, features, and how-to guides</span>
+                            <span style="opacity: 0.75;"> - Setup, features, and how-to guides</span>
                         </div>
                         <div>
                             <a href="https://github.com/sydlexius/Segment_Reporting" target="_blank" rel="noopener" style="color: inherit; text-decoration: underline;">
                                 GitHub Repository
                             </a>
-                            <span style="opacity: 0.6;"> - Source code, issues, and releases</span>
+                            <span style="opacity: 0.75;"> - Source code, issues, and releases</span>
                         </div>
                         <div>
                             <a href="https://github.com/sydlexius/Segment_Reporting/issues" target="_blank" rel="noopener" style="color: inherit; text-decoration: underline;">
                                 Report an Issue
                             </a>
-                            <span style="opacity: 0.6;"> - Bug reports and feature requests</span>
+                            <span style="opacity: 0.75;"> - Bug reports and feature requests</span>
                         </div>
                         <div>
                             <a href="https://github.com/sydlexius/Segment_Reporting/releases" target="_blank" rel="noopener" style="color: inherit; text-decoration: underline;">
                                 Releases
                             </a>
-                            <span style="opacity: 0.6;"> - Download latest DLL</span>
+                            <span style="opacity: 0.75;"> - Download latest DLL</span>
                         </div>
                         <div>
                             <a href="https://emby.media/community/index.php?/topic/146268-segment-reporting-plugin/" target="_blank" rel="noopener" style="color: inherit; text-decoration: underline;">
                                 Emby Forums
                             </a>
-                            <span style="opacity: 0.6;"> - Discussion, questions, and feedback</span>
+                            <span style="opacity: 0.75;"> - Discussion, questions, and feedback</span>
                         </div>
                     </div>
                 </div>

--- a/segment_reporting/Pages/segment_custom_query.html
+++ b/segment_reporting/Pages/segment_custom_query.html
@@ -66,7 +66,7 @@
         }
         #segmentCustomQueryPage .sr-chip-x {
             cursor: pointer;
-            opacity: 0.6;
+            opacity: 0.75;
             font-size: 1.1em;
             line-height: 1;
             margin-left: 2px;
@@ -116,7 +116,7 @@
         #segmentCustomQueryPage .sr-ac-empty {
             padding: 6px 10px;
             font-size: 0.85em;
-            opacity: 0.5;
+            opacity: 0.7;
             font-style: italic;
         }
     </style>
@@ -209,7 +209,7 @@
                         <tbody id="resultsTableBody">
                         </tbody>
                     </table>
-                    <div id="noResults" style="text-align: center; padding: 2em; color: rgba(128, 128, 128, 0.7);">
+                    <div id="noResults" style="text-align: center; padding: 2em; opacity: 0.75;">
                         No results to display. Execute a query to see results.
                     </div>
                 </div>

--- a/segment_reporting/Pages/segment_reporting_helpers.js
+++ b/segment_reporting/Pages/segment_reporting_helpers.js
@@ -977,6 +977,7 @@ function segmentReportingCreateInlineEditor(config) {
 
     var row = config.row;
     var active = false;
+    var saveInFlight = false;
 
     function getMarkerType(cell) {
         var marker = cell.getAttribute('data-marker');
@@ -1031,6 +1032,10 @@ function segmentReportingCreateInlineEditor(config) {
             // default behavior - per the resolved design, in-text-field nudging
             // is out of scope and arrows must never be hijacked on text inputs.
             input.addEventListener('keydown', function (e) {
+                // Ignore Enter/Escape while a save is in flight so a held or
+                // double Enter cannot enqueue duplicate writes and Escape cannot
+                // cancel mid-write.
+                if (saveInFlight) return;
                 if (e.key === 'Enter') {
                     e.preventDefault();
                     save();
@@ -1063,9 +1068,19 @@ function segmentReportingCreateInlineEditor(config) {
         if (config.onStart) config.onStart();
     }
 
-    function save() {
+    function setActionsDisabled(disabled) {
         var saveBtn = row.querySelector('.btn-save');
-        if (saveBtn) saveBtn.disabled = true;
+        var cancelBtn = row.querySelector('.btn-cancel');
+        if (saveBtn) saveBtn.disabled = disabled;
+        if (cancelBtn) cancelBtn.disabled = disabled;
+    }
+
+    function save() {
+        // Guard against re-entry (held/double Enter, repeated clicks) so a save
+        // already in flight cannot enqueue a duplicate set of write requests.
+        if (saveInFlight) return;
+        saveInFlight = true;
+        setActionsDisabled(true);
 
         var inputs = row.querySelectorAll('.tick-cell input');
         var updates = [];
@@ -1086,7 +1101,8 @@ function segmentReportingCreateInlineEditor(config) {
 
             var newTicks = segmentReportingTimeToTicks(newValue);
             if (newTicks === 0 && newValue !== '00:00:00.000') {
-                if (saveBtn) saveBtn.disabled = false;
+                saveInFlight = false;
+                setActionsDisabled(false);
                 segmentReportingShowError('Invalid time format for ' + getMarkerType(cell) + '. Use HH:MM:SS.fff');
                 return;
             }
@@ -1097,6 +1113,10 @@ function segmentReportingCreateInlineEditor(config) {
         }
 
         if (updates.length === 0) {
+            // No effective changes: clear the in-flight flag (no write happens)
+            // so cancel() runs and the row is restored instead of no-opping.
+            saveInFlight = false;
+            setActionsDisabled(false);
             cancel();
             return;
         }
@@ -1125,11 +1145,17 @@ function segmentReportingCreateInlineEditor(config) {
 
         chain
             .then(function () {
+                saveInFlight = false;
+                setActionsDisabled(false);
                 segmentReportingHideLoading();
                 segmentReportingShowSuccess('Segments updated successfully.');
                 if (config.onSaveComplete) config.onSaveComplete(updates);
             })
             .catch(function (error) {
+                // Re-enable the buttons so the row (still in edit mode) can be
+                // retried or cancelled, and clear the guard.
+                saveInFlight = false;
+                setActionsDisabled(false);
                 segmentReportingHideLoading();
                 console.error('Failed to save segments:', error);
                 segmentReportingShowError('Failed to save segment changes.');
@@ -1137,6 +1163,9 @@ function segmentReportingCreateInlineEditor(config) {
     }
 
     function cancel() {
+        // Do not cancel while a write is in flight; the buttons are disabled in
+        // that state, but guard the keyboard/programmatic paths too.
+        if (saveInFlight) return;
         restoreDisplay();
         if (config.onCancel) config.onCancel();
     }

--- a/segment_reporting/Pages/segment_reporting_helpers.js
+++ b/segment_reporting/Pages/segment_reporting_helpers.js
@@ -1025,6 +1025,21 @@ function segmentReportingCreateInlineEditor(config) {
             input.placeholder = '00:00:00.000';
             input.style.cssText = 'width: 120px; text-align: center; font-size: inherit; font-family: inherit; color: inherit; background: transparent; border: 1px solid rgba(128,128,128,0.4); border-radius: 3px; padding: 0.1em 0.3em;';
 
+            // M2 (issue #133): Enter saves the whole row, Escape cancels. Arrow
+            // keys are deliberately NOT captured here so the native text caret
+            // (Left/Right to move within the field, Up/Down as no-ops) keeps its
+            // default behavior - per the resolved design, in-text-field nudging
+            // is out of scope and arrows must never be hijacked on text inputs.
+            input.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    save();
+                } else if (e.key === 'Escape') {
+                    e.preventDefault();
+                    cancel();
+                }
+            });
+
             cell.innerHTML = '';
             cell.appendChild(input);
         }
@@ -1137,7 +1152,15 @@ function segmentReportingCreateInlineEditor(config) {
 
 // ── Offset adjustment (issue #80) ──
 
-var SEGMENT_REPORTING_OFFSET_STEP_TICKS = 2500000; // 250ms
+var SEGMENT_REPORTING_OFFSET_STEP_TICKS = 2500000; // 250ms (fine step; matches the +/- buttons)
+
+// Keyboard-nudge step sizes for the offset dialog spinbuttons (issue #133, M1).
+// These are intentionally hardcoded constants, not user settings:
+//   - Shift+Arrow nudges by a coarse 1s step.
+//   - PageUp/PageDown nudge by a 5s step.
+// One tick = 100ns, so 10,000,000 ticks = 1 second.
+var SEGMENT_REPORTING_OFFSET_COARSE_STEP_TICKS = 10000000; // 1s
+var SEGMENT_REPORTING_OFFSET_PAGE_STEP_TICKS = 50000000;   // 5s
 
 // items: array of { ItemId, introStart, introEnd, credits } where each tick
 // field is a number (absolute target) or null/undefined (leave untouched).
@@ -1206,6 +1229,14 @@ function segmentReportingApplyBulkSetStrict(items) {
 //              individual result: { introStart, introEnd, credits } absolute (or null)
 //              bulk result:       { introDelta, introEndDelta, creditsDelta } in ticks
 //   onClose  - optional function() called after the modal is dismissed
+//
+// Keyboard accessibility (issue #133): milestones M1 (spinbutton nudging) and
+// M3 (real modal: focus trap, initial/return focus, Enter=Apply, Escape=Cancel)
+// are implemented here; M2 (inline-editor Enter/Escape) lives in
+// segmentReportingCreateInlineEditor. M4 (in-table roving tabindex on marker
+// rows) and M5 (page-level/global shortcuts) are DEFERRED to a follow-up - all
+// nudging deliberately routes through this dialog (single commit/undo path) and
+// no handler is ever attached at the document/window level.
 function segmentReportingCreateOffsetModal(config) {
     if (document.querySelector('.segment-offset-overlay')) {
         return null;
@@ -1213,18 +1244,29 @@ function segmentReportingCreateOffsetModal(config) {
     var STEP = SEGMENT_REPORTING_OFFSET_STEP_TICKS;
     var isBulk = config.mode === 'bulk';
 
+    // Remember the element that opened the dialog so focus can be returned to it
+    // on close (issue #133, M3). Falls back to body if there is no active element.
+    var triggerEl = document.activeElement;
+
     var overlay = document.createElement('div');
     overlay.className = 'segment-offset-overlay';
     overlay.style.cssText = 'position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.5); z-index: 1000; display: flex; align-items: center; justify-content: center;';
 
+    // Real modal dialog semantics (issue #133, M3): role=dialog + aria-modal so
+    // assistive tech treats it as a focus-trapped modal, labelled by its heading.
     var dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
     dialog.style.cssText = 'background: ' + (config.isLight ? '#ffffff' : '#1f1f1f') +
         '; color: ' + (config.isLight ? '#000000' : '#ffffff') +
         '; border-radius: 6px; padding: 1.25em 1.5em; min-width: 360px; max-width: 90vw; box-shadow: 0 4px 24px rgba(0,0,0,0.4);';
 
+    var headingId = 'segmentOffsetHeading_' + Date.now();
     var heading = document.createElement('h3');
+    heading.id = headingId;
     heading.textContent = config.title;
     heading.style.cssText = 'margin: 0 0 0.75em 0; font-size: 1.1em;';
+    dialog.setAttribute('aria-labelledby', headingId);
     dialog.appendChild(heading);
 
     var state;
@@ -1244,25 +1286,36 @@ function segmentReportingCreateOffsetModal(config) {
         return (ticks < 0 ? '-' : '+') + segmentReportingTicksToTime(Math.abs(ticks));
     }
 
+    // Each row's step(d, stepTicks) nudges by `d` (-1 earlier / +1 later) times
+    // `stepTicks`. The +/- buttons pass the fine STEP; the keyboard handler
+    // (issue #133, M1) passes the fine, coarse (Shift), or page (PageUp/Down)
+    // step. valueNow()/valueMin() back the spinbutton ARIA state so screen
+    // readers announce the current target value as it changes.
     var rows = [];
     if (isBulk) {
         rows.push({ label: 'Intro', hint: 'moves whole intro', enabled: true,
-            step: function (d) { state.introDelta += d * STEP; },
+            step: function (d, stepTicks) { state.introDelta += d * stepTicks; },
             leftDisabled: function () { return false; },
+            valueNow: function () { return state.introDelta; },
+            valueMin: function () { return null; },
             display: function () { return fmtDelta(state.introDelta); } });
         rows.push({ label: 'Intro end', hint: 'trim / extend end', enabled: true,
-            step: function (d) { state.introEndDelta += d * STEP; },
+            step: function (d, stepTicks) { state.introEndDelta += d * stepTicks; },
             leftDisabled: function () { return false; },
+            valueNow: function () { return state.introEndDelta; },
+            valueMin: function () { return null; },
             display: function () { return fmtDelta(state.introEndDelta); } });
         rows.push({ label: 'Credits', hint: '', enabled: true,
-            step: function (d) { state.creditsDelta += d * STEP; },
+            step: function (d, stepTicks) { state.creditsDelta += d * stepTicks; },
             leftDisabled: function () { return false; },
+            valueNow: function () { return state.creditsDelta; },
+            valueMin: function () { return null; },
             display: function () { return fmtDelta(state.creditsDelta); } });
     } else {
         var hasIntro = state.introStart != null && state.introEnd != null;
         rows.push({ label: 'Intro', hint: 'moves whole intro, keeps length', enabled: hasIntro,
-            step: function (d) {
-                var delta = d * STEP;
+            step: function (d, stepTicks) {
+                var delta = d * stepTicks;
                 if (delta < 0) {
                     var present = [];
                     if (state.introStart != null) { present.push(state.introStart); }
@@ -1279,24 +1332,30 @@ function segmentReportingCreateOffsetModal(config) {
                 if (state.introEnd != null) { vals.push(state.introEnd); }
                 return vals.length === 0 || Math.min.apply(null, vals) <= 0;
             },
+            valueNow: function () { return state.introStart != null ? state.introStart : state.introEnd; },
+            valueMin: function () { return 0; },
             display: function () {
                 return segmentReportingTicksToTime(state.introStart) + ' -> ' + segmentReportingTicksToTime(state.introEnd);
             } });
         rows.push({ label: 'Intro end', hint: 'trim / extend the end only', enabled: state.introEnd != null,
-            step: function (d) {
+            step: function (d, stepTicks) {
                 if (state.introEnd != null) {
                     var floor = state.introStart != null ? state.introStart : 0;
-                    state.introEnd = Math.max(floor, state.introEnd + d * STEP);
+                    state.introEnd = Math.max(floor, state.introEnd + d * stepTicks);
                 }
             },
             leftDisabled: function () {
                 var floor = state.introStart != null ? state.introStart : 0;
                 return state.introEnd == null || state.introEnd <= floor;
             },
+            valueNow: function () { return state.introEnd; },
+            valueMin: function () { return state.introStart != null ? state.introStart : 0; },
             display: function () { return segmentReportingTicksToTime(state.introEnd); } });
         rows.push({ label: 'Credits', hint: '', enabled: state.credits != null,
-            step: function (d) { if (state.credits != null) { state.credits = Math.max(0, state.credits + d * STEP); } },
+            step: function (d, stepTicks) { if (state.credits != null) { state.credits = Math.max(0, state.credits + d * stepTicks); } },
             leftDisabled: function () { return state.credits == null || state.credits <= 0; },
+            valueNow: function () { return state.credits; },
+            valueMin: function () { return 0; },
             display: function () { return segmentReportingTicksToTime(state.credits); } });
     }
 
@@ -1315,8 +1374,18 @@ function segmentReportingCreateOffsetModal(config) {
         leftBtn.innerHTML = '&#8592;';
         leftBtn.style.cssText = 'padding: 0.1em 0.6em; font-size: 1.1em;';
 
+        // The value display doubles as an ARIA spinbutton (issue #133, M1): it is
+        // focusable and accepts arrow-key nudging. Each enabled spinbutton joins
+        // the dialog's tab order so Tab / Shift+Tab moves between marker rows.
         var valueEl = document.createElement('div');
-        valueEl.style.cssText = 'flex: 1 1 auto; text-align: center; font-family: monospace; min-width: 9em;';
+        valueEl.style.cssText = 'flex: 1 1 auto; text-align: center; font-family: monospace; min-width: 9em; border-radius: 3px; outline-offset: 2px;';
+        valueEl.setAttribute('role', 'spinbutton');
+        valueEl.setAttribute('aria-label', r.label + (config.title ? ' (' + config.title + ')' : ''));
+        if (r.enabled) {
+            valueEl.tabIndex = 0;
+        } else {
+            valueEl.setAttribute('aria-disabled', 'true');
+        }
 
         var rightBtn = document.createElement('button');
         rightBtn.type = 'button';
@@ -1325,13 +1394,61 @@ function segmentReportingCreateOffsetModal(config) {
         rightBtn.style.cssText = 'padding: 0.1em 0.6em; font-size: 1.1em;';
 
         function refresh() {
-            valueEl.textContent = r.display();
+            var text = r.display();
+            valueEl.textContent = text;
+            valueEl.setAttribute('aria-valuetext', text);
+            var now = r.valueNow();
+            if (now != null) {
+                valueEl.setAttribute('aria-valuenow', String(now));
+            } else {
+                valueEl.removeAttribute('aria-valuenow');
+            }
+            var min = r.valueMin();
+            if (min != null) {
+                valueEl.setAttribute('aria-valuemin', String(min));
+            } else {
+                valueEl.removeAttribute('aria-valuemin');
+            }
             leftBtn.disabled = !r.enabled || r.leftDisabled();
         }
 
         if (r.enabled) {
-            leftBtn.addEventListener('click', function () { r.step(-1); refreshAll(); });
-            rightBtn.addEventListener('click', function () { r.step(1); refreshAll(); });
+            leftBtn.addEventListener('click', function () { r.step(-1, STEP); refreshAll(); valueEl.focus(); });
+            rightBtn.addEventListener('click', function () { r.step(1, STEP); refreshAll(); valueEl.focus(); });
+
+            // Arrow-key nudging, scoped to this focused spinbutton only (never
+            // document/window level), so it cannot conflict with the Emby
+            // dashboard shell. ARIA-conventional direction: Up/Right = later,
+            // Down/Left = earlier. Shift = coarse 1s step; PageUp/Down = 5s.
+            // preventDefault fires only when the handler actually consumes the
+            // key, leaving Tab and everything else to the browser.
+            valueEl.addEventListener('keydown', function (e) {
+                var dir = 0;
+                var stepTicks = e.shiftKey ? SEGMENT_REPORTING_OFFSET_COARSE_STEP_TICKS : STEP;
+                switch (e.key) {
+                    case 'ArrowUp':
+                    case 'ArrowRight':
+                        dir = 1;
+                        break;
+                    case 'ArrowDown':
+                    case 'ArrowLeft':
+                        dir = -1;
+                        break;
+                    case 'PageUp':
+                        dir = 1;
+                        stepTicks = SEGMENT_REPORTING_OFFSET_PAGE_STEP_TICKS;
+                        break;
+                    case 'PageDown':
+                        dir = -1;
+                        stepTicks = SEGMENT_REPORTING_OFFSET_PAGE_STEP_TICKS;
+                        break;
+                    default:
+                        return; // not a key we handle; let it bubble
+                }
+                e.preventDefault();
+                r.step(dir, stepTicks);
+                refreshAll();
+            });
         } else {
             leftBtn.disabled = true;
             rightBtn.disabled = true;
@@ -1379,9 +1496,60 @@ function segmentReportingCreateOffsetModal(config) {
 
     var applyInFlight = false;
     function close() {
+        dialog.removeEventListener('keydown', onDialogKeydown);
         overlay.remove();
+        // Return focus to whatever opened the dialog (issue #133, M3).
+        if (triggerEl && typeof triggerEl.focus === 'function' && document.contains(triggerEl)) {
+            triggerEl.focus();
+        }
         if (config.onClose) { config.onClose(); }
     }
+
+    // Collect the dialog's focusable controls for the focus trap. Recomputed on
+    // each Tab so disabled buttons (e.g. a left-nudge at the floor) are skipped.
+    function focusableEls() {
+        var nodes = dialog.querySelectorAll(
+            'button:not([disabled]), [role="spinbutton"][tabindex="0"], a[href], input:not([disabled])'
+        );
+        return Array.prototype.slice.call(nodes);
+    }
+
+    // Dialog-scoped key handling (issue #133, M3):
+    //   - Escape cancels (unless an apply is in flight).
+    //   - Enter applies, EXCEPT when focus is on a button (let the button's own
+    //     activation handle Enter/Space) so Enter on Cancel does not apply.
+    //   - Tab / Shift+Tab is trapped within the dialog.
+    // Arrow keys are intentionally NOT handled here; they are consumed by the
+    // focused spinbutton's own listener, so this never interferes with nudging.
+    function onDialogKeydown(e) {
+        if (e.key === 'Escape') {
+            if (applyInFlight) { return; }
+            e.preventDefault();
+            close();
+            return;
+        }
+        if (e.key === 'Enter') {
+            var tag = (e.target.tagName || '').toLowerCase();
+            if (tag === 'button') { return; } // let the focused button activate
+            e.preventDefault();
+            applyBtn.click();
+            return;
+        }
+        if (e.key === 'Tab') {
+            var els = focusableEls();
+            if (!els.length) { return; }
+            var first = els[0];
+            var last = els[els.length - 1];
+            if (e.shiftKey && document.activeElement === first) {
+                e.preventDefault();
+                last.focus();
+            } else if (!e.shiftKey && document.activeElement === last) {
+                e.preventDefault();
+                first.focus();
+            }
+        }
+    }
+    dialog.addEventListener('keydown', onDialogKeydown);
 
     cancelBtn.addEventListener('click', function () { if (applyInFlight) { return; } close(); });
     overlay.addEventListener('click', function (e) { if (applyInFlight) { return; } if (e.target === overlay) { close(); } });
@@ -1407,6 +1575,12 @@ function segmentReportingCreateOffsetModal(config) {
     overlay.appendChild(dialog);
     document.body.appendChild(overlay);
 
+    // Initial focus into the dialog (issue #133, M3): the first enabled
+    // spinbutton if any, otherwise the Apply button, so a keyboard user lands
+    // inside the modal rather than behind it.
+    var firstSpin = dialog.querySelector('[role="spinbutton"][tabindex="0"]');
+    (firstSpin || applyBtn).focus();
+
     return { close: close };
 }
 
@@ -1418,6 +1592,10 @@ function segmentReportingShowOffsetSnackbar(message, onUndo) {
 
     var bar = document.createElement('div');
     bar.className = 'segment-offset-snackbar';
+    // role=status (issue #133, M3) so screen readers announce the result, with a
+    // keyboard-focusable Undo control (a real <button>, see below).
+    bar.setAttribute('role', 'status');
+    bar.setAttribute('aria-live', 'polite');
     bar.style.cssText = 'position: fixed; bottom: 1.5em; left: 50%; transform: translateX(-50%); background: #323232; color: #fff; padding: 0.75em 1.25em; border-radius: 4px; box-shadow: 0 2px 10px rgba(0,0,0,0.4); z-index: 1100; display: flex; align-items: center; gap: 1em;';
 
     var msgEl = document.createElement('span');

--- a/segment_reporting/Pages/segment_settings.html
+++ b/segment_reporting/Pages/segment_settings.html
@@ -92,7 +92,7 @@
                     <!-- Library Visibility -->
                     <div style="margin-bottom: 1.5em;">
                         <h4 style="margin: 0 0 0.8em 0; opacity: 0.85;">Library Visibility</h4>
-                        <p style="margin: 0 0 0.6em 0; font-size: 0.85em; opacity: 0.6;">
+                        <p style="margin: 0 0 0.6em 0; font-size: 0.85em; opacity: 0.75;">
                             Emby does not support intro/credit detection for Movie or Mixed libraries. You can hide them from the dashboard.
                         </p>
                         <div style="display: flex; flex-direction: column; gap: 0.6em;">
@@ -108,7 +108,7 @@
 
                         <!-- Per-library exclusions -->
                         <div id="perLibrarySection" style="margin-top: 1.2em; display: none;">
-                            <p style="margin: 0 0 0.6em 0; font-size: 0.85em; opacity: 0.6;">
+                            <p style="margin: 0 0 0.6em 0; font-size: 0.85em; opacity: 0.75;">
                                 Uncheck individual libraries to exclude them from the dashboard.
                             </p>
                             <div id="perLibraryList" style="display: flex; flex-direction: column; gap: 0.6em;"></div>

--- a/segment_reporting/Properties/AssemblyInfo.cs
+++ b/segment_reporting/Properties/AssemblyInfo.cs
@@ -38,5 +38,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.0.0")]
-[assembly: AssemblyFileVersion("1.5.0.0")]
+[assembly: AssemblyVersion("1.5.0.1")]
+[assembly: AssemblyFileVersion("1.5.0.1")]

--- a/segment_reporting/package-lock.json
+++ b/segment_reporting/package-lock.json
@@ -7,15 +7,30 @@
     "": {
       "name": "segment_reporting",
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-terser": "^1.0.0",
         "chart.js": "4.5.1",
         "esbuild": "^0.28.0",
         "eslint": "^10.4.1",
         "eslint-plugin-no-unsanitized": "^4.1.5",
+        "html-validate": "^11.5.1",
         "lefthook": "^2.1.9",
         "rollup": "^4.61.0",
         "sharp": "^0.34.5"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -576,6 +591,16 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@html-validate/stylish": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@html-validate/stylish/-/stylish-6.0.0.tgz",
+      "integrity": "sha512-d1/lI3qIXhGVJF3+MmKEBn1dRX6U4Z+BDaOdDI3E6SXcO+OQ7hC/3mSo6BIjwQlcuV6NdDOKm6QCrzIQL1EezQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.16.0 || >= 24.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1666,6 +1691,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -2021,6 +2056,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2122,6 +2174,94 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-validate": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/html-validate/-/html-validate-11.5.1.tgz",
+      "integrity": "sha512-Z0LaO7SAYjZsR382nzJoNlFASWYbsEeGomi5PVtwl1bcNVLfC1FWL4lnt2vjWhI+qijh1d14l1FV8Jf0G8aLkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/html-validate"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@html-validate/stylish": "^6.0.0",
+        "@sidvind/better-ajv-errors": "7.0.0",
+        "ajv": "^8.0.0",
+        "kleur": "^4.1.0",
+        "prompts": "^2.0.0",
+        "semver": "^7.0.0"
+      },
+      "bin": {
+        "html-validate": "bin/html-validate.mjs"
+      },
+      "engines": {
+        "node": "^22.22.0 || >= 24.8.0"
+      },
+      "peerDependencies": {
+        "@jest/globals": "^29.0.3 || ^30.0.0",
+        "@vitest/expect": "^3.0.0 || ^4.0.1",
+        "jest": "^29.0.3 || ^30.0.0",
+        "jest-snapshot": "^29.0.3 || ^30.0.0",
+        "vitest": "^3.0.0 || ^4.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@jest/globals": {
+          "optional": true
+        },
+        "@vitest/expect": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "jest-snapshot": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/html-validate/node_modules/@sidvind/better-ajv-errors": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-7.0.0.tgz",
+      "integrity": "sha512-imVsp5D3KxJ8+uUmu2dsLKnFg3qdX952v/L1gZoCa0NO2ivhQWHMpYM2KmpFrRXHWFjlqkNZ/935nxiTqXEi1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^22.12 || >= 24.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      }
+    },
+    "node_modules/html-validate/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/html-validate/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -2225,6 +2365,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lefthook": {
@@ -2540,6 +2690,20 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2550,6 +2714,30 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2558,6 +2746,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -2716,6 +2914,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/smob": {
       "version": "1.5.0",

--- a/segment_reporting/package.json
+++ b/segment_reporting/package.json
@@ -8,16 +8,20 @@
     "build:restore": "node scripts/build-js.mjs restore",
     "build:thumb": "node scripts/optimize-thumb.mjs",
     "lint:js": "eslint Pages/*.js --ignore-pattern '*.min.js' --no-warn-ignored",
+    "lint:html": "html-validate Pages/*.html",
+    "a11y:axe": "node ../scripts/axe-a11y.mjs",
     "verify:hooks": "cd .. && bash scripts/check-hooks.sh",
     "prepare": "cd .. && npx --prefix segment_reporting lefthook install && node segment_reporting/scripts/fix-hooks.mjs"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-terser": "^1.0.0",
     "chart.js": "4.5.1",
     "esbuild": "^0.28.0",
     "eslint": "^10.4.1",
     "eslint-plugin-no-unsanitized": "^4.1.5",
+    "html-validate": "^11.5.1",
     "lefthook": "^2.1.9",
     "rollup": "^4.61.0",
     "sharp": "^0.34.5"


### PR DESCRIPTION
Combines two accessibility follow-ups to #57 plus a CodeQL fix, per maintainer request to land them together.

## #132 - a11y linting (layer:infra)
- `html-validate` (WCAG preset) wired into pre-commit, CI, and the pre-push gate on `Pages/*.html`; surfaced HTML/ARIA violations fixed.
- `scripts/axe-a11y.mjs` committed: axe-core via Playwright (reuses the capture-screenshots login/nav), local/UAT-only, not in the CI gate.
- Low-contrast muted text raised on Custom Query, Settings, About. The Dashboard contrast case is theme-dependent (can't be verified statically) and is **documented** for a runtime `npm run a11y:axe` pass rather than guessed.
- DEVELOPER.md documents both tiers.

## #133 (M1-M3) - keyboard shortcuts (layer:frontend)
- Arrow-key nudging of intro/credits markers in the shared offset dialog (`role="spinbutton"`, fine 250ms / Shift = 1s coarse / PageUp-Down 5s), Enter = Apply, Escape = Cancel.
- Inline editor Enter = Save / Escape = Cancel (native caret arrows preserved).
- Offset dialog hardened to `role="dialog"` + `aria-modal` with a focus trap and focus return; snackbar is `role="status"` with a keyboard-reachable Undo.
- Handlers scoped to the focused control; no document/window-level key capture.
- Open design questions resolved as: Tab between rows + arrow nudge, 1s coarse step, dialog-only nudging, no global shortcuts.
- **M4** (in-table roving tabindex) and **M5** (page-level shortcuts) deferred to a follow-up.
- USER_GUIDE keyboard-shortcuts section + DEVELOPER helper notes.

## CodeQL #10
- Pinned `scripts/fuzz/Dockerfile` base image to a sha256 digest (won't show resolved until the scan re-runs post-merge).

Closes #132
Closes #133

Note: combines `layer:infra` + `layer:frontend` in one PR at maintainer request; larger than the usual size target.