### PR TITLE
ci: harden GitHub Actions workflows (CodeQL #11-#18)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,10 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+# Restrict the default GITHUB_TOKEN to read-only; jobs widen scope explicitly.
+permissions:
+  contents: read
+
 jobs:
   claude-review:
     # Optional: Filter by PR author
@@ -27,13 +31,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1.0.135
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Restrict the default GITHUB_TOKEN to read-only; jobs widen scope explicitly.
+permissions:
+  contents: read
+
 jobs:
   claude:
     if: |
@@ -26,13 +30,14 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1.0.135
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
Resolves the open code-scanning (Scorecard) alerts in the GitHub Actions workflows. CI-config only, no plugin code.

## Pinned dependencies (PinnedDependencies)
- #15 claude-code-review.yml:30 - pin actions/checkout v4 -> df4cb1c069e1874edd31b4311f1884172cec0e10 (v6.0.3)
- #16 claude-code-review.yml:36 - pin anthropics/claude-code-action v1 -> 70a6e5256e9e2366a1ed5c041904a982ba3a328f (v1.0.135)
- #17 claude.yml:29 - pin actions/checkout v4 -> df4cb1c069e1874edd31b4311f1884172cec0e10 (v6.0.3)
- #18 claude.yml:35 - pin anthropics/claude-code-action v1 -> 70a6e5256e9e2366a1ed5c041904a982ba3a328f (v1.0.135)

The checkout SHA matches the one already used in build.yml so the repo pins a single checkout version.

## Token permissions (TokenPermissions)
- #13 claude-code-review.yml:1 - add a top-level read-only permissions block (contents: read). The job retains its explicit wider scopes.
- #14 claude.yml:1 - add a top-level read-only permissions block (contents: read). The job retains its explicit wider scopes.
- #11 build.yml:90 - add an explicit job-level permissions: contents: read to the build job so every job declares its scope. The release job keeps contents: write, which softprops/action-gh-release genuinely needs to publish release assets.
- #12 dependabot-merge.yml:21 - left as-is: already least-privilege. Top-level is permissions: {}, and the merge job needs contents: write + pull-requests: write to squash-merge and delete the branch. There is no checkout step.

## Hardening
- Added persist-credentials: false to the checkout steps in claude.yml and claude-code-review.yml (build.yml already had it).

## Validation
- actionlint clean on all four workflow files.
- Full pre-push gate green ("All pre-push checks passed").

Note: CodeQL/Scorecard will not show these alerts resolved until the scan re-runs on this PR / after merge. Findings #11 and #12 concern write-scoped tokens that are genuinely required for their jobs (release publishing, dependabot auto-merge) and may remain as accepted by Scorecard even with the top-level restriction in place.