### PR TITLE
ci(dependabot): add checks: read for gh pr checks --watch

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      checks: read
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       startsWith(github.event.workflow_run.head_branch, 'dependabot/')


### PR DESCRIPTION
## Summary

The `gh pr checks --watch --required` call in the merge job requires the `checks: read` permission to poll check-run status. Without it the step fails with a 403 and the auto-merge never completes.

- Add `checks: read` to the job-level `permissions:` block in `dependabot-merge.yml`

Mirrors the fix already applied to [mxlrcgo-svc #160](https://github.com/sydlexius/mxlrcgo-svc/pull/160).

## Test plan
- [ ] Merge a future dependabot PR and confirm the merge job completes without 403