### PR TITLE
ci: bump anthropics/claude-code-action to v1.0.151 in claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1.0.140
+        uses: anthropics/claude-code-action@806af32823ef69c8ef357086c573a902af641307 # v1.0.151
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Bumps the SHA-pinned `anthropics/claude-code-action` in `.github/workflows/claude.yml` (the on-demand `@claude` assistant) from v1.0.140 to the current latest, **v1.0.151**.

## Why

Dependabot's grouped PR #146 (1.0.140 -> 1.0.148) was closed because it also patched the now-deleted `claude-code-review.yml` (removed in #148) and conflicted. `claude.yml` is intentionally retained, so its pinned action is bumped here directly. Going straight to the latest patch means Dependabot has nothing left to refile for this action.

## Notes

- SHA-pinned with a `# v1.0.151` comment, per repo CI convention.
- No automated Claude PR review is reintroduced; this only updates the on-demand `@claude` assistant workflow.

## Verification

- `actionlint` clean on `claude.yml`.
- Sole `claude-code-action@` reference in the repo, now at v1.0.151.