### PR TITLE
chore: disable CodeRabbit auto-review (manual reviews only)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+# Disable CodeRabbit auto-review to honor this org's manual-reviews-only policy.
+# Manual `@coderabbitai review` still triggers a full review on demand.
+reviews:
+  auto_review:
+    enabled: false


### PR DESCRIPTION
Adds a minimal `.coderabbit.yaml` (`reviews.auto_review.enabled: false`) so this repo does not auto-review on push (org manual-reviews-only policy). Manual `@coderabbitai review` still works. This repo had no `.coderabbit.yaml` and would otherwise inherit the new org default.