### PR TITLE
chore: onboard to orchestrate conventions (.gates.toml + resume pointer + gitignore)

### DIFF
--- a/.gates.toml
+++ b/.gates.toml
@@ -1,0 +1,12 @@
+# Gate definition read by the cc-orchestrator gate-runner (prep-pr / handle-review /
+# review-stack). Delegates to the repo's own CI-parity gate: `make gate` ->
+# `scripts/pre-push-gate.sh` (build -warnaserror -> dotnet test -> dotnet format
+# --verify-no-changes -> eslint Pages -> html-validate Pages).
+#
+# PREREQ: the default gate builds the 4.10 Emby ABI, which needs the reference DLLs in
+# segment_reporting/embylibs/ (gitignored; fetched by CI from a GitHub release). A fresh
+# clone or git worktree must have them present. This intentionally mirrors the repo's
+# design -- the pre-push gate and CI build the 4.10 ABI; only the pre-commit dotnet-format
+# check uses the ABI-independent 4.9 Emby SDK (see lefthook.yml).
+[prep_pr]
+gate = "make gate"

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ tests/segment_reporting.Fuzz/testcases/
 ## diagnostic builds (proprietary; never commit). See RCA checkpoint memory.
 embylibs/
 segment_reporting/embylibs/
+
+# Orchestrate session checkpoint (machine-local, transient; never committed)
+SESSION-STATE.md

--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,4 @@ embylibs/
 segment_reporting/embylibs/
 
 # Orchestrate session checkpoint (machine-local, transient; never committed)
-SESSION-STATE.md
+/SESSION-STATE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## >> ON SESSION START / RESUME: read SESSION-STATE.md FIRST (if present) <<
+
+`SESSION-STATE.md` (repo root; gitignored, machine-local) is the orchestrate session
+checkpoint - read it before doing anything when asked to resume / pick up work. It holds
+only non-derivable intent + pointers (status banner, next actions); reboot-durable
+derivables (in-flight PRs via `gh pr list`, worktrees via `git worktree list`) are
+reconstructed on demand, not mirrored. Absent on a fresh checkout; created on the first
+orchestrate session.
+
 ## Project Overview
 
 Segment Reporting is an Emby server plugin (C#/.NET) that caches media segment markers (Intros, Credits) into a local SQLite database and provides admin-facing reporting, charts, inline editing, and bulk management through embedded web pages. Licensed GPL-3.0.


### PR DESCRIPTION
## Summary

Onboard Segment_Reporting to the cc-orchestrator orchestrate conventions. Additive config
only - no code change.

- **`.gates.toml`** (Form A) delegates to `make gate` -> `scripts/pre-push-gate.sh`, the
  repo's CI-parity gate (build -warnaserror -> dotnet test -> dotnet format -> eslint ->
  html-validate). Documents the 4.10 `embylibs/` prereq (gitignored, CI-fetched), mirroring
  the repo's design that the pre-push gate + CI build the 4.10 ABI.
- **CLAUDE.md** gains the `SESSION START / RESUME` pointer for the orchestrate resume protocol.
- **`.gitignore`** ignores the machine-local, transient `SESSION-STATE.md` checkpoint.

## Test plan

- [x] Ran the cc-orchestrator gate-runner against this repo: it read the new `.gates.toml`
      and invoked `make gate`. Build (-warnaserror), `dotnet test` (42 passed), `dotnet
      format --verify-no-changes`, and `npm run lint:js` (eslint) all passed.
- [~] `npm run lint:html` (html-validate) could not run in the local shell (the devDep was
      not on PATH); CI installs it and runs the full gate. This is an environment gap, not a
      gate-config defect - the delegate is the repo's own `make gate`.
- [x] `.gates.toml` parses (tomllib).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new CI parity preparation gate to run automated PR checks alongside existing validation.
  * Updated git ignore rules to prevent machine-local session checkpoint files from being committed.
* **Documentation**
  * Added guidance for resuming sessions by reading session checkpoint information first (when present).
  * Documented the expected gate workflow prerequisites and validation expectations, including relevant ABI references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->