### PR TITLE
ci: repin Emby reference assemblies to a release that still exists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,14 @@ on:
 permissions:
   contents: read
 
+# Emby prunes old releases from MediaBrowser/Emby.Releases, so a pinned version
+# eventually 404s rather than merely going stale -- 4.10.0.13 was pinned here and
+# has since been deleted upstream, which is what broke this workflow. Keep the
+# version in exactly one place per workflow so a bump cannot half-apply, and see
+# the tracking issue for making this resilient rather than merely current.
+env:
+  EMBY_VERSION: "4.10.0.19"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -37,12 +45,12 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Fetch Emby 4.10.0.13 reference assemblies
+      - name: Fetch Emby ${{ env.EMBY_VERSION }} reference assemblies
         run: |
           set -euo pipefail
           mkdir -p segment_reporting/embylibs
           extract_dir="$(mktemp -d)"
-          url="https://github.com/MediaBrowser/Emby.Releases/releases/download/4.10.0.13/emby-server-freebsd14_4.10.0.13_amd64.tar.xz"
+          url="https://github.com/MediaBrowser/Emby.Releases/releases/download/${EMBY_VERSION}/emby-server-freebsd14_${EMBY_VERSION}_amd64.tar.xz"
           curl -fsSL "$url" -o /tmp/emby.tar.xz
           tar xJf /tmp/emby.tar.xz -C "$extract_dir" --wildcards \
             '*/MediaBrowser.Model.dll' '*/MediaBrowser.Common.dll' \
@@ -107,12 +115,12 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Fetch Emby 4.10.0.13 reference assemblies
+      - name: Fetch Emby ${{ env.EMBY_VERSION }} reference assemblies
         run: |
           set -euo pipefail
           mkdir -p segment_reporting/embylibs
           extract_dir="$(mktemp -d)"
-          url="https://github.com/MediaBrowser/Emby.Releases/releases/download/4.10.0.13/emby-server-freebsd14_4.10.0.13_amd64.tar.xz"
+          url="https://github.com/MediaBrowser/Emby.Releases/releases/download/${EMBY_VERSION}/emby-server-freebsd14_${EMBY_VERSION}_amd64.tar.xz"
           curl -fsSL "$url" -o /tmp/emby.tar.xz
           tar xJf /tmp/emby.tar.xz -C "$extract_dir" --wildcards \
             '*/MediaBrowser.Model.dll' '*/MediaBrowser.Common.dll' \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,11 @@ concurrency:
   group: codeql-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Emby prunes old releases from MediaBrowser/Emby.Releases, so a pinned version
+# eventually 404s rather than merely going stale. Keep it in one place per workflow.
+env:
+  EMBY_VERSION: "4.10.0.19"
+
 permissions:
   contents: read
 
@@ -53,13 +58,13 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      - name: Fetch Emby 4.10.0.13 reference assemblies
+      - name: Fetch Emby ${{ env.EMBY_VERSION }} reference assemblies
         if: matrix.language == 'csharp'
         run: |
           set -euo pipefail
           mkdir -p segment_reporting/embylibs
           extract_dir="$(mktemp -d)"
-          url="https://github.com/MediaBrowser/Emby.Releases/releases/download/4.10.0.13/emby-server-freebsd14_4.10.0.13_amd64.tar.xz"
+          url="https://github.com/MediaBrowser/Emby.Releases/releases/download/${EMBY_VERSION}/emby-server-freebsd14_${EMBY_VERSION}_amd64.tar.xz"
           curl -fsSL "$url" -o /tmp/emby.tar.xz
           tar xJf /tmp/emby.tar.xz -C "$extract_dir" --wildcards \
             '*/MediaBrowser.Model.dll' '*/MediaBrowser.Common.dll' \


### PR DESCRIPTION
## What

Repins the Emby reference-assembly download from **4.10.0.13** (deleted upstream) to **4.10.0.19** (current), and collapses the version string into a single `EMBY_VERSION` env var per workflow.

## Why

Both `build.yml` and `codeql.yml` curl an Emby release tarball to get the `MediaBrowser.*` and `Emby.Naming` reference assemblies the plugin compiles against. Emby prunes old releases from `MediaBrowser/Emby.Releases`, and **4.10.0.13 has been deleted**. The pinned URL now 404s, curl exits 22, and the step dies.

That single 404 is the entire reason CI is red here. It takes out `build` **and** `Analyze (csharp)` (codeql.yml fetches the same tarball), which is why every open Dependabot PR in this repo is failing for reasons that have nothing whatsoever to do with the dependency it bumps. Unblocking this should clear #162 and #163 on a rebase.

This is a deletion, not staleness: the oldest surviving 4.10.x is now 4.10.0.16.

The version was also written out five times across the two workflows -- in the step name *and* twice in each URL -- so a bump could half-apply and leave a mismatched fetch. Now it is one env var per file.

## Verification

Checked against the live release, not assumed:

- New URL returns **HTTP 200**, 36,370,428 bytes.
- Tarball genuinely contains all four assemblies the build extracts:
  `MediaBrowser.Model.dll`, `MediaBrowser.Common.dll`, `MediaBrowser.Controller.dll`, `Emby.Naming.dll`.
- `actionlint` clean on both workflows; YAML parses.
- No `4.10.0.13` remains outside the explanatory comment.

## This repins, it does not fix

Upstream prunes releases on a rolling basis, so **4.10.0.19 will 404 too, eventually** -- this same breakage is scheduled to recur, just later. A durable fix means not depending on an upstream artifact that gets deleted out from under us (vendoring the assemblies somewhere we control, or caching them). I'll file a tracking issue; it needs a decision about where those DLLs should live, which is not a call to make inside a hotfix.