### PR TITLE
chore: add issue and PR templates adapted from stillwater

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,41 @@
+---
+name: Bug Report
+about: Something is broken or behaving incorrectly
+labels: bug
+---
+
+<!-- Agent hints: set all three before submitting -->
+[mode: direct] <!-- plan | direct -->
+[model: sonnet] <!-- opus | sonnet | haiku -->
+[effort: medium] <!-- low | medium | high | xhigh | max -->
+
+## Description
+
+<!-- What is broken? What did you expect to happen? -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What should happen -->
+
+## Actual Behavior
+
+<!-- What actually happens -->
+
+## Environment
+
+- Plugin version:
+- Emby server version:
+- Emby ABI channel (4.9 or 4.10 build):
+- Platform (Docker / Unraid / Windows / bare metal):
+- Browser (if a UI or reporting page bug):
+
+## Additional Context
+
+<!-- Emby server log excerpts, screenshots, related issues.
+     Redact media titles and library names: this repo is public. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,44 @@
+---
+name: Feature Request
+about: New feature or enhancement
+labels: enhancement
+---
+
+<!-- Agent hints: set all three before submitting -->
+[mode: plan] <!-- plan | direct -->
+[model: sonnet] <!-- opus | sonnet | haiku -->
+[effort: medium] <!-- low | medium | high | xhigh | max -->
+
+## Summary
+
+<!-- One sentence: what does this add or change? -->
+
+## Problem / Motivation
+
+<!-- Why is this needed? What pain does it solve? -->
+
+## Proposed Solution
+
+<!-- How should it work? Include any relevant design notes.
+     The design document in docs/plans/ is the authoritative spec: note any
+     place this diverges from it. -->
+
+## Acceptance Criteria
+
+- [ ]
+- [ ]
+- [ ]
+
+## Documentation impact
+
+<!-- Which of the three docs this touches, if any. See the table in CLAUDE.md. -->
+
+- [ ] `README.md` (headline feature or install change)
+- [ ] `docs/USER_GUIDE.md` (admin-facing workflow, button, or setting)
+- [ ] `docs/DEVELOPER.md` (API endpoint, schema, build pipeline)
+- [ ] New or updated screenshot in `docs/Screenshots/`
+- [ ] No documentation impact
+
+## Additional Context
+
+<!-- References, related issues, mockups. -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,27 @@
+---
+name: Task / Chore
+about: Refactor, cleanup, docs, config, CI, or other non-feature work
+labels: chore
+---
+
+<!-- Agent hints: set all three before submitting -->
+[mode: direct] <!-- plan | direct -->
+[model: haiku] <!-- opus | sonnet | haiku -->
+[effort: low] <!-- low | medium | high | xhigh | max -->
+
+## Description
+
+<!-- What needs to be done and why? -->
+
+## Acceptance Criteria
+
+<!-- Prefer criteria that can be checked by running something, not by reading
+     the diff. "Verified by breaking X and confirming CI goes red" beats
+     "the step was added". -->
+
+- [ ]
+- [ ]
+
+## Additional Context
+
+<!-- References, related issues. -->

--- a/.github/PULL_REQUEST_TEMPLATE/chore.md
+++ b/.github/PULL_REQUEST_TEMPLATE/chore.md
@@ -1,0 +1,28 @@
+## Summary
+
+- What changed and why (focus on the why; 1-3 bullets).
+- Note anything reviewers should look at first.
+
+## Linked issue
+
+Closes #
+
+(Use `Part of #N` for a slice of a larger issue that is not yet fully resolved.)
+
+## Pre-flight checklist
+
+- [ ] Pre-push gate green locally (`make gate`), or run via `/prep-pr`, which invokes it.
+- [ ] Code review pass complete; critical and important findings fixed before pushing.
+- [ ] Commits squashed before the first push.
+- [ ] Labels set on `gh pr create --label ...`.
+- [ ] No user-visible behavior change, so no docs or screenshot update is required.
+      If that is not true, use the default PR template instead.
+
+## Test plan
+
+- [ ] `make gate` passes locally.
+- [ ] `actionlint` clean, if any workflow changed.
+- [ ] `node --test 'tests/js/*.test.mjs'` passes, if any JS changed (not yet in
+      `make gate` or CI, see #177).
+- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
+  - [ ]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+## Summary
+
+- What changed and why (focus on the why; 1-3 bullets).
+- Note any user-visible behavior change.
+- Call out anything reviewers should look at first.
+
+## Linked issue
+
+Closes #
+
+(Use `Part of #N` for a slice of a larger issue that is not yet fully resolved.
+GitHub binds the keyword to the ONE number after it, so repeat it for each:
+`Closes #1, closes #2`.)
+
+## Pre-flight checklist
+
+- [ ] Pre-push gate green locally (`make gate`), or run via `/prep-pr`, which invokes it.
+- [ ] Code review pass complete; critical and important findings fixed before pushing.
+- [ ] Commits squashed before the first push (reviewers read the full changeset at once).
+- [ ] Labels set on `gh pr create --label ...`.
+- [ ] Screenshot attached for any UI change, and `docs/Screenshots/` refreshed if an
+      existing screenshot no longer matches. Screenshots must not contain real
+      media library names.
+- [ ] Docs updated in the same commit for any documented behavior change:
+      `README.md` (features, install), `docs/USER_GUIDE.md` (admin workflows,
+      labels, settings), `docs/DEVELOPER.md` (API, schema, build, CI). See the
+      table in `CLAUDE.md`.
+- [ ] Version bumped in `Properties/AssemblyInfo.cs` if this ships a release.
+
+## Test plan
+
+- [ ] `make gate` passes locally: Release build with analyzers as errors,
+      `dotnet test`, `dotnet format --verify-no-changes`, eslint, html-validate.
+- [ ] `node --test 'tests/js/*.test.mjs'` passes, if any JS under `scripts/` or
+      `tests/js/` changed. Note: this suite is not yet wired into `make gate` or
+      CI (see #177), so it must be run by hand.
+- [ ] 4.9 ABI still compiles if the plugin source changed
+      (`dotnet build segment_reporting/segment_reporting.csproj -c Release -p:EmbyAbi=4.9`).
+      CI enforces this, but catching it locally is cheaper.
+- [ ] UAT performed against a real Emby server for user-visible changes
+      (`make uat`, or `make uat-deploy` plus manual steps). Run the plugin, not
+      just the test suite.
+- [ ] Manual UAT steps (list the specific flows exercised):
+  - [ ]
+  - [ ]
+- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
+  - [ ]


### PR DESCRIPTION
## Summary

- The repo had no issue or PR templates, so both were freeform and the agent hint line (`[mode] [model] [effort]`) that drives dispatch was applied only by habit rather than prompted.
- Ported the Stillwater set and **adapted** each item to this stack rather than copying it. Every checklist line was verified true of this repo before being included.
- Reviewers should look first at what was dropped, below: a checklist that tells contributors to run things that do not exist is worse than no checklist.

## Linked issue

None. Repo hygiene, requested directly.

## What was dropped from the Stillwater originals, and why

| Stillwater item | Disposition |
|---|---|
| "CI label gate fails without a label" | **Dropped.** Verified: this repo has no label gate. The line would have been false. |
| `needs-docs-review` / `docs: not-required` labels | **Dropped.** Neither label exists here. Replaced with an explicit three-document checklist per `CLAUDE.md`. |
| `make check-openapi` | **Dropped.** No OpenAPI spec in this project. |
| `templ generate` / `*_templ.go` | **Dropped.** Not a templ project. |
| `go test -race ./...` | **Replaced** with `make gate`. |

## What was added for this repo

- Dual-ABI check: `-p:EmbyAbi=4.9` still compiles when plugin source changes. CI enforces it; catching it locally is cheaper.
- `make uat` against a real Emby server for user-visible changes, since the SQLite stack cannot be exercised outside Emby.
- Screenshot freshness for `docs/Screenshots/`, plus the standing rule that screenshots must not contain real media library names.
- The three-document update rule (`README.md`, `docs/USER_GUIDE.md`, `docs/DEVELOPER.md`) from `CLAUDE.md`.
- Bug report now asks for plugin version, Emby version, and **ABI channel**, which is the first thing needed to triage a load failure.
- A note that `node --test` must be run by hand, because it is not yet covered by `make gate` or CI (#177).
- Multi-issue closing keywords note: GitHub binds `Closes` to the one number after it, so it must be repeated per issue.

## Labels

Adds a `chore` label, which `task.md` declares and the repo did not have. `bug` and `enhancement` already existed; all three frontmatter references were verified to resolve.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), via the lefthook pre-push hook.
- [x] Code review pass complete; no critical or important findings.
- [x] Commits squashed before the first push (single commit).
- [x] Labels set on `gh pr create --label ...`.
- [x] No user-visible behavior change, so no docs or screenshot update is required. These are contributor-facing templates; the plugin is untouched.

## Test plan

- [x] `make gate` passes locally.
- [x] `actionlint` clean (no workflow changed; hook ran it as a no-op).
- [x] No JS changed, so `node --test` is not applicable.
- [x] Verified all three issue-template `labels:` values resolve against `gh label list`.
- [x] Verified no em-dashes and no emoji in any of the five files.
- [ ] **Reviewer follow-up:** the templates render correctly only once on `main`. Worth confirming after merge that the issue chooser shows all three types and that `?template=chore.md` resolves.
