### PR TITLE
fix(deps): bump brace-expansion to 5.0.8 for GHSA-mh99-v99m-4gvg

### DIFF
--- a/segment_reporting/package-lock.json
+++ b/segment_reporting/package-lock.json
@@ -1840,16 +1840,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-from": {


### PR DESCRIPTION
## Summary

- Bumps `brace-expansion` from 5.0.7 to 5.0.8, clearing Scorecard alert 20 (GHSA-mh99-v99m-4gvg, high: DoS via unbounded expansion causing an out-of-memory process crash).
- Transitive and dev-only (`dev: true`, reached via build tooling), so the shipped plugin DLL is byte-identical and no release is warranted.
- Lockfile only. `package.json` is unchanged, so the "Lockfile integrity" job's regenerate-in-place check stays a no-op.

## Linked issue

No tracking issue. Raised by Scorecard alert 20 on the code-scanning surface.

## Verification

- `npm audit` in `segment_reporting/`: 2 high before, **0 vulnerabilities** after (`fast-uri` was resolved separately by a transitive bump in #182/#183).
- `npm ci` succeeds on the bumped lockfile.
- `make gate` green: Release build with analyzers as errors, 42 xUnit tests, format check, eslint, html-validate.

The advisory's first-patched version is exactly 5.0.8. Note 5.0.8 narrows its `engines` from `18 || 20 || >=22` to `20 || >=22`; that is a non-issue here, since `.nvmrc` pins Node 24 and `package.json` declares `engines.node >= 24`.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete.
- [x] Single commit.
- [x] Labels set.
- [ ] Screenshot. N/A: no UI change.
- [ ] Docs updated. N/A: no documented behavior change.
- [ ] Version bumped in `Properties/AssemblyInfo.cs`. N/A: dev-only dependency, DLL unchanged.

## Test plan

- [x] `make gate` passes locally.
- [x] `npm audit` reports 0 vulnerabilities.
- [x] `npm ci` installs cleanly from the bumped lockfile.
- [ ] `node --test`. N/A: no JS logic changed.
- [ ] UAT against a real Emby server. N/A: dev dependency, not shipped.
- [ ] Reviewer follow-ups:
  - [ ] Confirm Scorecard alert 20 closes on the next scan of `main` after merge.
