### PR TITLE
ci: run the JS test suite in the pre-push gate and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,12 @@ jobs:
       - name: Lint HTML accessibility (html-validate)
         run: npm run lint:html --prefix segment_reporting
 
+      # Enforced here as well as in scripts/pre-push-gate.sh so the suite runs
+      # even when local hooks are bypassed. A quoted glob, not a directory:
+      # `node --test tests/js/` throws ERR_UNSUPPORTED_DIR_IMPORT on Node 22/24.
+      - name: Run JavaScript tests
+        run: node --test 'tests/js/*.test.mjs'
+
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -78,7 +78,7 @@ can always run the underlying command shown below by hand.
 | `make format` | `dotnet format` | Apply C# code formatting in place. |
 | `make format-check` | `dotnet format --verify-no-changes` | Verify formatting without writing changes (matches CI). |
 | `make lint` | `npm run lint:js` | ESLint the page JavaScript. |
-| `make gate` | `bash scripts/pre-push-gate.sh` | Full CI-parity pre-push gate (Release build + format-check + lint). |
+| `make gate` | `bash scripts/pre-push-gate.sh` | Full CI-parity pre-push gate (Release build + format-check + lint + JS unit tests). |
 | `make hooks` | `bash scripts/check-hooks.sh` | Verify the git hooks are wired to lefthook. |
 | `make hooks-install` | `npx lefthook install` + `fix-hooks.mjs` | Install the pre-commit and pre-push git hooks. |
 | `make docs-deps` | `pip install -r dev-requirements.txt` | Install the docs toolchain (ProperDocs + Material). |
@@ -2413,8 +2413,13 @@ branches. Runs on `ubuntu-latest`.
    --no-build` runs the xUnit suite (see the Testing section)
 10. **Check code formatting** -- `dotnet format --verify-no-changes` ensures
    code style matches `.editorconfig` rules
-11. **Upload artifact** -- the compiled DLL is uploaded as a build artifact
-12. **Verify 4.9 ABI also compiles** -- `dotnet build ... -p:EmbyAbi=4.9` so a PR
+11. **Lint JavaScript** -- `npm run lint:js` (ESLint over `Pages/*.js`)
+12. **Lint HTML accessibility** -- `npm run lint:html` (html-validate over
+    `Pages/*.html`)
+13. **Run JavaScript tests** -- `node --test 'tests/js/*.test.mjs'` runs the
+    node:test suite covering the repo-root build tooling (see the Testing section)
+14. **Upload artifact** -- the compiled DLL is uploaded as a build artifact
+15. **Verify 4.9 ABI also compiles** -- `dotnet build ... -p:EmbyAbi=4.9` so a PR
     that breaks the 4.9 channel fails CI (the default gate builds the 4.10 ABI)
 
 **Key point:** JS minification happens *before* `dotnet build` so the minified
@@ -2615,6 +2620,30 @@ build in CI and the local pre-push gate.
 
 The same validators are also fuzzed with SharpFuzz (Docker, local-only); see
 [Fuzzing the SQL Validators](#fuzzing-the-sql-validators-docker-manual) below.
+
+### JavaScript Unit Tests (node:test)
+
+`tests/js/` covers the repo-root Node modules that support the build and CI
+tooling, currently `scripts/emby-version.mjs`: version parsing, four-part
+numeric comparison (a string sort would place `4.10.0.20` below `4.10.0.9`),
+release-line filtering, and the classification branches that decide whether a
+pinned Emby version is current, stale, or deleted upstream. Run them with:
+
+```bash
+node --test 'tests/js/*.test.mjs'
+```
+
+Quote the glob and do not pass a directory: `node --test tests/js/` throws
+`ERR_UNSUPPORTED_DIR_IMPORT` on Node 22 and 24.
+
+The suite runs in `scripts/pre-push-gate.sh` (so `make gate` and the lefthook
+pre-push stage both enforce it) and as the "Run JavaScript tests" step in the CI
+build job, so enforcement does not depend on local hooks. It previously ran in
+none of them (#177), which meant a regression in the version watcher could land
+with every gate green.
+
+These files are deliberately outside ESLint's scope; see the scope note at the
+top of `segment_reporting/eslint.config.mjs`.
 
 ### Accessibility (a11y) Testing
 

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -6,7 +6,8 @@
 #
 # CI runs, in order: minify JS, restore deps, `dotnet build <sln> -c Release
 # -warnaserror`, `dotnet test <sln> -c Release --no-build`,
-# `dotnet format --verify-no-changes`, `npm run lint:js`. A
+# `dotnet format --verify-no-changes`, `npm run lint:js`,
+# `npm run lint:html`, `node --test 'tests/js/*.test.mjs'`. A
 # Release build already minifies the JS (MinifyJS target, BeforeTargets
 # CoreCompile) and restores the originals (RestoreJS target, AfterTargets
 # Build) on its own, so we do not minify separately. The catch: RestoreJS only
@@ -64,6 +65,18 @@ echo "=== HTML accessibility lint (npm run lint:html) ==="
 # duplicate ids, missing img alt, etc). Runtime contrast checks (axe) are a
 # local UAT-only tool and are intentionally not part of this gate.
 npm run lint:html --prefix "$NPM_PREFIX"
+
+echo ""
+echo "=== JavaScript unit tests (node --test) ==="
+# Covers the pure-logic Node modules under scripts/ (Emby version parsing,
+# four-part numeric comparison, release classification). Without this step the
+# suite ran nowhere automatically, so a regression in the version watcher would
+# have left every gate green (#177).
+#
+# A quoted glob, not a directory: `node --test tests/js/` throws
+# ERR_UNSUPPORTED_DIR_IMPORT on Node 22 and 24. Quoted so the glob is expanded
+# by node, not the shell.
+node --test 'tests/js/*.test.mjs'
 
 echo ""
 echo "All pre-push checks passed (matches CI build job)."

--- a/segment_reporting/eslint.config.mjs
+++ b/segment_reporting/eslint.config.mjs
@@ -1,5 +1,11 @@
 import noUnsanitized from "eslint-plugin-no-unsanitized";
 
+// Scope note (#177): this config covers the browser-side plugin pages only.
+// The repo-root Node modules (scripts/*.mjs, tests/js/*.mjs) are deliberately
+// NOT linted. Covering them needs a separate Node-globals block and a lint
+// invocation reaching outside segment_reporting/, which buys little while those
+// files stay small and are now exercised by `node --test` in the gate and CI.
+// Revisit if repo-root JS grows beyond the version-watcher helpers.
 export default [
     {
         ignores: ["Pages/*.min.js", "node_modules/**", "scripts/**"]


### PR DESCRIPTION
## Summary

- The `tests/js/` suite added in #174 ran in **nothing** automatically: absent from `make gate`, CI, and lefthook. It passed only when someone ran `node --test` by hand.
- That suite holds the regression tests for the `classify()` self-target bug CodeRabbit caught in #174, where a shrinking upstream release window made the watcher propose the version it was already pinned to. A reintroduction would have left every gate green while the tests written to catch it never ran.
- Wires it into `scripts/pre-push-gate.sh` (one edit covering both `make gate` and the lefthook pre-push stage) and adds a distinct CI step so enforcement does not depend on local hooks.

## Linked issue

Closes #177

## Review guidance

The load-bearing question is whether the gate actually **fails** on a failing test, not merely whether it runs one. That was verified by deliberately corrupting an assertion (see Test plan) rather than by inspection.

Two details worth a look:
- The invocation is a quoted glob, `node --test 'tests/js/*.test.mjs'`. A bare directory throws `ERR_UNSUPPORTED_DIR_IMPORT` on Node 22 and 24, and quoting keeps expansion in node rather than the shell.
- The gate script's header comment enumerates the CI step order, so it is updated in lockstep. The CI step list in `docs/DEVELOPER.md` had already drifted before this change (it omitted both existing lint steps); that is corrected here too.

## Decision recorded (AC4)

`scripts/*.mjs` and `tests/js/*.mjs` stay **outside ESLint's scope**. Covering them needs a Node-globals block and a lint invocation reaching outside `segment_reporting/`, which buys little while those files are small and now exercised by `node --test`. Recorded as a scope note at the top of `segment_reporting/eslint.config.mjs` and in DEVELOPER.md, so the next reader finds it where they would look rather than in this PR body.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete.
- [x] Single commit.
- [x] Labels set.
- [ ] Screenshot. N/A: no UI change.
- [x] Docs updated: DEVELOPER.md gains a "JavaScript Unit Tests (node:test)" section; `make gate` description and the CI step list corrected.
- [ ] Version bumped in `Properties/AssemblyInfo.cs`. N/A: CI/dev tooling only, shipped DLL unchanged.

## Test plan

- [x] `make gate` passes with the new step visible: `=== JavaScript unit tests (node --test) ===`, 14 pass / 0 fail.
- [x] **AC3 negative test**: corrupted one assertion in `tests/js/emby-version.test.mjs` (`parseVersion('4.10.0.19')` expecting `[9,9,9,9]`). `node --test` exited 1 and the full gate exited 1, reporting `actual: [4,10,0,19] / expected: [9,9,9,9]`. Reverted; test file restored with zero diff and 14/14 passing.
- [x] `actionlint` clean on `build.yml`.
- [ ] 4.9 ABI compile. N/A: no plugin source changed (CI still enforces it).
- [ ] UAT against a real Emby server. N/A: no user-visible change.
- [ ] Reviewer follow-ups:
  - [ ] Confirm the "Run JavaScript tests" step appears and passes in this PR's CI run, which is the AC2 evidence this checklist cannot self-certify.
